### PR TITLE
Refactor UI into mobile hamburger navigation

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1,4 +1,9 @@
-async function init() {
+let menuToggleButton = null;
+let menuBackdrop = null;
+let menuCloseButton = null;
+let menuContainer = null;
+
+async function loadMap() {
   const config = await fetch('/config').then(r => r.json());
   const script = document.createElement('script');
   script.src = `https://maps.googleapis.com/maps/api/js?key=${config.mapsApiKey}`;
@@ -11,6 +16,7 @@ function initMap() {
   const map = new google.maps.Map(document.getElementById('map'), {
     center: { lat: -26.2041, lng: 28.0473 },
     zoom: 12,
+    disableDefaultUI: true,
   });
   if (navigator.geolocation) {
     navigator.geolocation.getCurrentPosition(pos => {
@@ -20,10 +26,189 @@ function initMap() {
   }
 }
 
-function toggleUI() {
-  document.getElementById('topbar').classList.toggle('hidden');
-  document.getElementById('search').classList.toggle('hidden');
+function updateMenuState(isOpen) {
+  document.body.classList.toggle('menu-open', isOpen);
+  if (menuToggleButton) {
+    menuToggleButton.setAttribute('aria-expanded', String(isOpen));
+  }
+  if (menuCloseButton) {
+    menuCloseButton.setAttribute('aria-expanded', String(isOpen));
+  }
+  if (menuContainer) {
+    menuContainer.setAttribute('aria-hidden', String(!isOpen));
+    if (isOpen) {
+      menuContainer.focus({ preventScroll: true });
+    }
+  }
+  if (!isOpen && menuToggleButton) {
+    menuToggleButton.focus({ preventScroll: true });
+  }
 }
 
-document.addEventListener('DOMContentLoaded', init);
+function openMenu() {
+  updateMenuState(true);
+}
+
+function closeMenu() {
+  updateMenuState(false);
+}
+
+function toggleMenu(force) {
+  const shouldOpen = typeof force === 'boolean'
+    ? force
+    : !document.body.classList.contains('menu-open');
+  updateMenuState(shouldOpen);
+}
+
+function enhanceSearch(search) {
+  if (!search) return;
+  search.classList.add('menu-search');
+  const input = search.querySelector('input');
+  if (input) {
+    if (!input.id) {
+      input.id = 'route-search';
+    }
+    if (!search.querySelector('label')) {
+      const label = document.createElement('label');
+      label.htmlFor = input.id;
+      label.textContent = 'Route search';
+      search.insertBefore(label, input);
+    }
+    input.setAttribute('aria-label', 'Search routes');
+  }
+}
+
+function relocateContent(topbar) {
+  const mapElement = document.getElementById('map');
+  const search = document.getElementById('search');
+  if (search) {
+    search.removeAttribute('style');
+    enhanceSearch(search);
+    const brand = topbar.querySelector('.menu-brand');
+    if (brand && brand.nextSibling) {
+      topbar.insertBefore(search, brand.nextSibling);
+    } else {
+      topbar.appendChild(search);
+    }
+  }
+
+  const extraPanels = Array.from(document.body.children).filter(el => {
+    if (el === topbar || el === mapElement || el === menuToggleButton || el === menuBackdrop) return false;
+    return !(el.id === 'search');
+  });
+
+  extraPanels.forEach(panel => {
+    if (panel.matches('#map')) return;
+    panel.removeAttribute('style');
+    if (panel.classList && panel.classList.contains('grid')) {
+      const wrapper = document.createElement('div');
+      wrapper.classList.add('menu-section');
+      wrapper.appendChild(panel);
+      topbar.appendChild(wrapper);
+    } else {
+      panel.classList.add('menu-section');
+      topbar.appendChild(panel);
+    }
+  });
+}
+
+function buildMenu() {
+  const topbar = document.getElementById('topbar');
+  if (!topbar) return;
+
+  topbar.setAttribute('role', 'dialog');
+  topbar.setAttribute('aria-modal', 'false');
+  topbar.setAttribute('aria-label', 'iTaxi-Finder navigation');
+  topbar.setAttribute('aria-hidden', 'true');
+  if (!topbar.hasAttribute('tabindex')) {
+    topbar.setAttribute('tabindex', '-1');
+  }
+  menuContainer = topbar;
+
+  menuToggleButton = document.createElement('button');
+  menuToggleButton.type = 'button';
+  menuToggleButton.className = 'menu-toggle';
+  menuToggleButton.setAttribute('aria-label', 'Open navigation menu');
+  menuToggleButton.setAttribute('aria-controls', topbar.id || 'topbar');
+  menuToggleButton.setAttribute('aria-expanded', 'false');
+  menuToggleButton.innerHTML = '<span></span><span></span><span></span>';
+  document.body.appendChild(menuToggleButton);
+
+  menuBackdrop = document.createElement('div');
+  menuBackdrop.className = 'menu-backdrop';
+  document.body.appendChild(menuBackdrop);
+
+  const links = Array.from(topbar.querySelectorAll('a'));
+  const closeButton = topbar.querySelector('button');
+
+  topbar.textContent = '';
+
+  if (closeButton) {
+    closeButton.className = 'menu-close';
+    closeButton.type = 'button';
+    closeButton.textContent = 'Close menu';
+    closeButton.removeAttribute('onclick');
+    menuCloseButton = closeButton;
+    topbar.appendChild(closeButton);
+  } else {
+    menuCloseButton = document.createElement('button');
+    menuCloseButton.type = 'button';
+    menuCloseButton.className = 'menu-close';
+    menuCloseButton.textContent = 'Close menu';
+    topbar.appendChild(menuCloseButton);
+  }
+
+  menuCloseButton.setAttribute('aria-controls', topbar.id || 'topbar');
+  menuCloseButton.setAttribute('aria-expanded', 'false');
+  menuCloseButton.setAttribute('aria-label', 'Close navigation menu');
+
+  if (links.length) {
+    const brandLink = links.shift();
+    if (brandLink) {
+      brandLink.classList.add('menu-brand');
+      brandLink.textContent = 'iTaxi-Finder';
+      topbar.appendChild(brandLink);
+    }
+
+    if (links.length) {
+      const nav = document.createElement('nav');
+      nav.className = 'menu-links';
+      nav.setAttribute('aria-label', 'Site sections');
+      links.forEach(link => {
+        link.classList.add('menu-link');
+        nav.appendChild(link);
+      });
+      topbar.appendChild(nav);
+    }
+  }
+
+  relocateContent(topbar);
+
+  menuToggleButton.addEventListener('click', () => toggleMenu());
+  if (menuCloseButton) {
+    menuCloseButton.addEventListener('click', () => closeMenu());
+  }
+  menuBackdrop.addEventListener('click', () => closeMenu());
+
+  topbar.addEventListener('click', event => {
+    if (event.target instanceof HTMLElement && event.target.matches('a')) {
+      closeMenu();
+    }
+  });
+
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && document.body.classList.contains('menu-open')) {
+      closeMenu();
+    }
+  });
+}
+
+function toggleUI(force) {
+  toggleMenu(force);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  buildMenu();
+  loadMap();
+});
 

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,40 +1,264 @@
-body, html {
+:root {
+  --menu-width: min(85vw, 360px);
+  --menu-accent: #134074;
+  --menu-accent-light: rgba(19, 64, 116, 0.08);
+  --menu-radius: 18px;
+  font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+html,
+body {
   margin: 0;
   padding: 0;
   height: 100%;
+  overflow: hidden;
+  color: #1a1a1a;
+  background: #f5f7fb;
 }
+
 #map {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
-  right: 0;
-  bottom: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
 }
+
+.menu-toggle {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  width: 52px;
+  height: 52px;
+  padding: 14px;
+  border: none;
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  z-index: 2000;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.menu-toggle:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 4px;
+}
+
+.menu-toggle span {
+  display: block;
+  height: 3px;
+  width: 100%;
+  border-radius: 999px;
+  background: #fff;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+body.menu-open .menu-toggle {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+body.menu-open .menu-toggle span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+body.menu-open .menu-toggle span:nth-child(2) {
+  opacity: 0;
+}
+
+body.menu-open .menu-toggle span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+.menu-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 1200;
+}
+
+body.menu-open .menu-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 #topbar {
   position: fixed;
   top: 0;
   left: 0;
-  right: 0;
-  height: 50px;
-  background: rgba(255,255,255,0.5);
+  bottom: 0;
+  width: var(--menu-width);
+  max-width: 420px;
+  padding: 84px 22px 28px;
+  box-sizing: border-box;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(12px);
+  transform: translateX(-110%);
+  transition: transform 0.35s ease;
   display: flex;
-  align-items: center;
-  padding: 0 10px;
-  z-index: 1000;
+  flex-direction: column;
+  gap: 24px;
+  z-index: 1600;
+  overflow-y: auto;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
 }
-#topbar a {
-  margin-right: 15px;
+
+body.menu-open #topbar {
+  transform: translateX(0);
+  box-shadow: 18px 0 45px rgba(15, 37, 64, 0.25);
+}
+
+.menu-close {
+  align-self: flex-start;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--menu-accent);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.menu-close:focus-visible {
+  outline: 2px solid rgba(19, 64, 116, 0.35);
+  outline-offset: 3px;
+}
+
+.menu-brand {
+  font-size: 1.5rem;
+  font-weight: 700;
   text-decoration: none;
-  color: #000;
-  font-weight: bold;
+  color: var(--menu-accent);
+  letter-spacing: 0.01em;
 }
-#search {
-  position: fixed;
-  top: 60px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1000;
-  background: rgba(255,255,255,0.8);
-  padding: 5px;
+
+.menu-links {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
-.hidden { display: none; }
+
+.menu-links a {
+  text-decoration: none;
+  color: #0f253f;
+  background: var(--menu-accent-light);
+  padding: 14px 16px;
+  border-radius: var(--menu-radius);
+  font-weight: 600;
+  box-shadow: 0 6px 18px rgba(19, 64, 116, 0.08);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.menu-links a:hover,
+.menu-links a:focus-visible {
+  transform: translateX(6px);
+  background: rgba(19, 64, 116, 0.16);
+  outline: none;
+}
+
+.menu-search {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.menu-search label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 37, 63, 0.7);
+}
+
+.menu-search input {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: var(--menu-radius);
+  border: 1px solid rgba(15, 37, 63, 0.12);
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: inset 0 2px 4px rgba(15, 37, 63, 0.05);
+}
+
+.menu-search input:focus {
+  outline: 2px solid rgba(19, 64, 116, 0.35);
+  outline-offset: 2px;
+}
+
+.menu-section {
+  background: rgba(19, 64, 116, 0.06);
+  border-radius: 24px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 10px 26px rgba(15, 37, 64, 0.08);
+}
+
+.menu-section h1,
+.menu-section h2,
+.menu-section h3 {
+  margin: 0;
+  color: #0f253f;
+}
+
+.menu-section p {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(15, 37, 63, 0.88);
+}
+
+.menu-section .grid {
+  display: grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.menu-section .grid a {
+  width: 100% !important;
+  padding: 14px 16px !important;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--menu-radius);
+  text-decoration: none !important;
+  color: var(--menu-accent) !important;
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px rgba(19, 64, 116, 0.08);
+}
+
+.menu-section .grid a:hover,
+.menu-section .grid a:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(19, 64, 116, 0.25);
+}
+
+@media (max-width: 480px) {
+  .menu-toggle {
+    top: 12px;
+    left: 12px;
+    width: 48px;
+    height: 48px;
+    padding: 12px;
+  }
+
+  #topbar {
+    padding: 74px 18px 24px;
+  }
+
+  .menu-section {
+    padding: 16px;
+  }
+
+  .menu-section .grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the fixed link bar with a mobile-first hamburger navigation that slides menu content above the map
- restyle shared panels, route search, and community lists to live inside the foreground drawer while keeping Google Maps visible behind
- add accessibility and usability improvements such as focus handling, aria attributes, and backdrop interactions for the off-canvas menu

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d569a0d8e4832e9379078af52de8c4