### PR TITLE
Adjust menu height and improve overlay dragging

### DIFF
--- a/client/about.html
+++ b/client/about.html
@@ -9,7 +9,7 @@
 </head>
 <body class="page map-background page-about">
     <div id="topbar" data-nav-open="false">
-      <a href="/" class="topbar__brand">iTaxi-Finder</a>
+      <a href="/index.html" class="topbar__brand">iTaxi-Finder</a>
       <button type="button" class="topbar__menu" aria-expanded="false" aria-controls="topbar-navigation" data-nav-toggle>
       <span class="topbar__menu-icon" aria-hidden="true">
         <span class="topbar__menu-line"></span>

--- a/client/admin-route-finder.html
+++ b/client/admin-route-finder.html
@@ -9,7 +9,7 @@
 </head>
 <body class="page map-background page-admin-route-finder">
     <div id="topbar" data-nav-open="false">
-      <a href="/" class="topbar__brand">iTaxi-Finder</a>
+      <a href="/index.html" class="topbar__brand">iTaxi-Finder</a>
       <button type="button" class="topbar__menu" aria-expanded="false" aria-controls="topbar-navigation" data-nav-toggle>
       <span class="topbar__menu-icon" aria-hidden="true">
         <span class="topbar__menu-line"></span>

--- a/client/app.js
+++ b/client/app.js
@@ -904,6 +904,23 @@ function setAccountMenuOpen(state, open) {
   if (state.container) {
     state.container.classList.toggle('topbar__account--open', isOpen);
   }
+
+  if (typeof window !== 'undefined') {
+    const realignOverlays = () => {
+      const mapElement = document.getElementById('map');
+      if (mapElement) {
+        repositionMapControls(mapElement);
+      } else {
+        applyLayoutOffsets(getControlOffset());
+      }
+    };
+
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(realignOverlays);
+    } else {
+      setTimeout(realignOverlays, 0);
+    }
+  }
 }
 
 function closeAccountMenu() {

--- a/client/app.js
+++ b/client/app.js
@@ -98,9 +98,9 @@ function pageAllowsMobileBodyDrag() {
   if (typeof document === 'undefined' || !document.body) {
     return false;
   }
-  const allowedClasses = [
-    'page-route-adder',
-    'page-route-finder',
+  const { classList } = document.body;
+
+  const handleOnlyClasses = [
     'page-home',
     'page-delivery',
     'page-community',
@@ -108,9 +108,12 @@ function pageAllowsMobileBodyDrag() {
     'page-about',
   ];
 
-  return allowedClasses.some(className =>
-    document.body.classList.contains(className)
-  );
+  if (handleOnlyClasses.some(className => classList.contains(className))) {
+    return false;
+  }
+
+  const allowedClasses = ['page-route-adder', 'page-route-finder'];
+  return allowedClasses.some(className => classList.contains(className));
 }
 
 function notifyAuthChange(session) {

--- a/client/app.js
+++ b/client/app.js
@@ -98,9 +98,18 @@ function pageAllowsMobileBodyDrag() {
   if (typeof document === 'undefined' || !document.body) {
     return false;
   }
-  return (
-    document.body.classList.contains('page-route-adder') ||
-    document.body.classList.contains('page-route-finder')
+  const allowedClasses = [
+    'page-route-adder',
+    'page-route-finder',
+    'page-home',
+    'page-delivery',
+    'page-community',
+    'page-registration',
+    'page-about',
+  ];
+
+  return allowedClasses.some(className =>
+    document.body.classList.contains(className)
   );
 }
 

--- a/client/app.js
+++ b/client/app.js
@@ -604,6 +604,8 @@ function setupResponsiveNavigation() {
 
     if (isDesktop) {
       navContainer.style.removeProperty('--mobile-nav-max-height');
+      navContainer.style.removeProperty('--mobile-nav-height');
+      navContainer.classList.remove('mobile-nav--scrollable');
       return;
     }
 
@@ -640,7 +642,7 @@ function setupResponsiveNavigation() {
 
     totalHeight = Math.ceil(totalHeight);
 
-    const safeSpacing = Math.max(0, Math.round(viewportHeight * 0.02));
+    const safeSpacing = Math.max(12, Math.round(viewportHeight * 0.015));
     const availableHeight = Math.max(0, Math.round(viewportHeight - safeSpacing));
     let targetHeight = totalHeight;
     if (availableHeight && totalHeight > availableHeight) {
@@ -649,10 +651,15 @@ function setupResponsiveNavigation() {
 
     if (!targetHeight || targetHeight <= 0) {
       navContainer.style.removeProperty('--mobile-nav-max-height');
+      navContainer.style.removeProperty('--mobile-nav-height');
+      navContainer.classList.remove('mobile-nav--scrollable');
       return;
     }
 
     navContainer.style.setProperty('--mobile-nav-max-height', `${targetHeight}px`);
+    navContainer.style.setProperty('--mobile-nav-height', `${targetHeight}px`);
+    const needsScroll = totalHeight - targetHeight > 1;
+    navContainer.classList.toggle('mobile-nav--scrollable', needsScroll);
   };
 
   const focusableSelectors = [
@@ -1332,17 +1339,17 @@ function bindOverlayDragging(overlay) {
   const visualHandle = overlay.querySelector('[data-drag-handle]');
   const computeHorizontalPeek = size => {
     if (!Number.isFinite(size) || size <= 0) return 0;
-    const preferred = Math.round(size * 0.3);
-    const clamped = Math.max(72, Math.min(preferred, 140));
-    const maxVisible = Math.max(size - 24, Math.round(size * 0.65));
-    return Math.max(32, Math.min(clamped, maxVisible));
+    const preferred = Math.round(size * 0.32);
+    const base = Math.max(108, Math.min(preferred, 184));
+    const maxVisible = Math.max(size - 24, Math.round(size * 0.75));
+    return Math.min(Math.max(base, 96), maxVisible);
   };
   const computeVerticalPeek = size => {
     if (!Number.isFinite(size) || size <= 0) return 0;
-    const preferred = Math.round(size * 0.35);
-    const clamped = Math.max(60, Math.min(preferred, 128));
-    const maxVisible = Math.max(size - 28, Math.round(size * 0.7));
-    return Math.max(36, Math.min(clamped, maxVisible));
+    const preferred = Math.round(size * 0.38);
+    const base = Math.max(88, Math.min(preferred, 152));
+    const maxVisible = Math.max(size - 28, Math.round(size * 0.78));
+    return Math.min(Math.max(base, 72), maxVisible);
   };
 
   try {
@@ -1444,7 +1451,7 @@ function bindOverlayDragging(overlay) {
         const liveRect = overlay.getBoundingClientRect();
         const viewportWidth = window.innerWidth || document.documentElement.clientWidth || liveRect.right;
         const viewportHeight = window.innerHeight || document.documentElement.clientHeight || liveRect.bottom;
-        const margin = 16;
+        const margin = 20;
         const horizontalPeek = computeHorizontalPeek(liveRect.width);
         const verticalPeek = computeVerticalPeek(liveRect.height);
 
@@ -1509,7 +1516,7 @@ function bindOverlayDragging(overlay) {
 
       const viewportWidth = window.innerWidth || document.documentElement.clientWidth || width;
       const viewportHeight = window.innerHeight || document.documentElement.clientHeight || height;
-      const margin = 16;
+      const margin = 20;
       const horizontalPeek = computeHorizontalPeek(width);
       const verticalPeek = computeVerticalPeek(height);
 

--- a/client/app.js
+++ b/client/app.js
@@ -599,7 +599,10 @@ function setupResponsiveNavigation() {
   const updateMobileNavHeight = () => {
     if (!navContainer) return;
 
-    if (navMediaQuery.matches) {
+    const isDesktop = navMediaQuery.matches;
+    topbar.dataset.navMode = isDesktop ? 'desktop' : 'overlay';
+
+    if (isDesktop) {
       navContainer.style.removeProperty('--mobile-nav-max-height');
       return;
     }
@@ -637,8 +640,8 @@ function setupResponsiveNavigation() {
 
     totalHeight = Math.ceil(totalHeight);
 
-    const margin = Math.max(16, Math.min(48, Math.round(viewportHeight * 0.06)));
-    const availableHeight = Math.max(0, Math.round(viewportHeight - margin));
+    const safeSpacing = Math.max(0, Math.round(viewportHeight * 0.02));
+    const availableHeight = Math.max(0, Math.round(viewportHeight - safeSpacing));
     let targetHeight = totalHeight;
     if (availableHeight && totalHeight > availableHeight) {
       targetHeight = availableHeight;
@@ -802,6 +805,9 @@ function setupResponsiveNavigation() {
     } else {
       setNavState(false);
     }
+
+    updateMobileNavHeight();
+    toggleBodyScroll(false);
   };
 
   if (typeof navMediaQuery.addEventListener === 'function') {
@@ -1324,6 +1330,20 @@ function bindOverlayDragging(overlay) {
   if (!overlay || overlay.dataset.draggableBound === 'true') return;
 
   const visualHandle = overlay.querySelector('[data-drag-handle]');
+  const computeHorizontalPeek = size => {
+    if (!Number.isFinite(size) || size <= 0) return 0;
+    const preferred = Math.round(size * 0.3);
+    const clamped = Math.max(72, Math.min(preferred, 140));
+    const maxVisible = Math.max(size - 24, Math.round(size * 0.65));
+    return Math.max(32, Math.min(clamped, maxVisible));
+  };
+  const computeVerticalPeek = size => {
+    if (!Number.isFinite(size) || size <= 0) return 0;
+    const preferred = Math.round(size * 0.35);
+    const clamped = Math.max(60, Math.min(preferred, 128));
+    const maxVisible = Math.max(size - 28, Math.round(size * 0.7));
+    return Math.max(36, Math.min(clamped, maxVisible));
+  };
 
   try {
     const computedStyle = window.getComputedStyle(overlay);
@@ -1424,9 +1444,9 @@ function bindOverlayDragging(overlay) {
         const liveRect = overlay.getBoundingClientRect();
         const viewportWidth = window.innerWidth || document.documentElement.clientWidth || liveRect.right;
         const viewportHeight = window.innerHeight || document.documentElement.clientHeight || liveRect.bottom;
-        const margin = 12;
-        const horizontalPeek = Math.max(28, Math.min(Math.round(liveRect.width * 0.2), 96));
-        const verticalPeek = Math.max(24, Math.min(Math.round(liveRect.height * 0.25), 80));
+        const margin = 16;
+        const horizontalPeek = computeHorizontalPeek(liveRect.width);
+        const verticalPeek = computeVerticalPeek(liveRect.height);
 
         let nextLeft = parseFloat(overlay.style.left) || liveRect.left;
         let nextTop = parseFloat(overlay.style.top) || liveRect.top;
@@ -1489,9 +1509,9 @@ function bindOverlayDragging(overlay) {
 
       const viewportWidth = window.innerWidth || document.documentElement.clientWidth || width;
       const viewportHeight = window.innerHeight || document.documentElement.clientHeight || height;
-      const margin = 12;
-      const horizontalPeek = Math.max(28, Math.min(Math.round(width * 0.2), 96));
-      const verticalPeek = Math.max(24, Math.min(Math.round(height * 0.25), 80));
+      const margin = 16;
+      const horizontalPeek = computeHorizontalPeek(width);
+      const verticalPeek = computeVerticalPeek(height);
 
       let nextLeft = startLeft + deltaX;
       let nextTop = startTop + deltaY;

--- a/client/app.js
+++ b/client/app.js
@@ -6,7 +6,6 @@ let adminRouteFinderState;
 let overlayBodyIdCounter = 0;
 let routeSaveDialogState;
 let accountDropdownState;
-let mobileViewportQuery = null;
 
 const STORAGE_KEYS = {
   driverProfile: 'itaxiFinderDriverProfile',
@@ -76,46 +75,6 @@ function safeStorageRemove(key) {
   }
 }
 
-function isMobileViewport() {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-  if (!mobileViewportQuery && typeof window.matchMedia === 'function') {
-    mobileViewportQuery = window.matchMedia('(max-width: 899px)');
-  }
-  if (mobileViewportQuery) {
-    return mobileViewportQuery.matches;
-  }
-  const width =
-    window.innerWidth ||
-    (typeof document !== 'undefined' && document.documentElement
-      ? document.documentElement.clientWidth
-      : 0);
-  return width <= 899;
-}
-
-function pageAllowsMobileBodyDrag() {
-  if (typeof document === 'undefined' || !document.body) {
-    return false;
-  }
-  const { classList } = document.body;
-
-  const handleOnlyClasses = [
-    'page-home',
-    'page-delivery',
-    'page-community',
-    'page-registration',
-    'page-about',
-  ];
-
-  if (handleOnlyClasses.some(className => classList.contains(className))) {
-    return false;
-  }
-
-  const allowedClasses = ['page-route-adder', 'page-route-finder'];
-  return allowedClasses.some(className => classList.contains(className));
-}
-
 function notifyAuthChange(session) {
   if (typeof document === 'undefined') return;
   const detail = { session: session || null };
@@ -154,18 +113,6 @@ function getLoggedInUser() {
   const session = getAuthSession();
   if (!session || !session.user) return null;
   return session.user;
-}
-
-function getRegisteredContributorDetails() {
-  const user = getLoggedInUser();
-  if (!user) {
-    return normalizeContributor();
-  }
-
-  return normalizeContributor({
-    username: user.username,
-    homeTown: user.homeTown,
-  });
 }
 
 function getAuthHeaders() {
@@ -569,10 +516,6 @@ async function fallbackToIpLocation(map) {
 function getControlOffset() {
   const topbar = document.getElementById('topbar');
   const navHeight = topbar ? topbar.getBoundingClientRect().height : 56;
-  const root = document.documentElement;
-  if (root) {
-    root.style.setProperty('--topbar-height', `${Math.round(navHeight)}px`);
-  }
   let offset = navHeight + 12;
   const banner = document.querySelector('.delivery-banner');
   if (banner && banner.isConnected) {
@@ -646,78 +589,6 @@ function setupResponsiveNavigation() {
 
   const navMediaQuery = window.matchMedia('(min-width: 900px)');
   let restoreFocusTo = null;
-  const getViewportHeight = () => {
-    if (window.visualViewport && typeof window.visualViewport.height === 'number') {
-      return window.visualViewport.height;
-    }
-    return window.innerHeight || document.documentElement.clientHeight || 0;
-  };
-
-  const updateMobileNavHeight = () => {
-    if (!navContainer) return;
-
-    const isDesktop = navMediaQuery.matches;
-    topbar.dataset.navMode = isDesktop ? 'desktop' : 'overlay';
-
-    if (isDesktop) {
-      navContainer.style.removeProperty('--mobile-nav-max-height');
-      navContainer.style.removeProperty('--mobile-nav-height');
-      navContainer.classList.remove('mobile-nav--scrollable');
-      return;
-    }
-
-    const viewportHeight = getViewportHeight();
-    if (!viewportHeight) {
-      navContainer.style.removeProperty('--mobile-nav-max-height');
-      return;
-    }
-
-    const computed = window.getComputedStyle(navContainer);
-    const paddingTop = Number.parseFloat(computed.paddingTop) || 0;
-    const paddingBottom = Number.parseFloat(computed.paddingBottom) || 0;
-    const columnGap =
-      Number.parseFloat(computed.rowGap || computed.columnGap || computed.gap) || 0;
-
-    const header = navContainer.querySelector('.mobile-nav__header');
-    const headerRect = header && header.isConnected ? header.getBoundingClientRect() : null;
-    const headerHeight = headerRect && Number.isFinite(headerRect.height)
-      ? headerRect.height
-      : 0;
-
-    let linksHeight = 0;
-    if (links && links.isConnected) {
-      linksHeight = links.scrollHeight;
-    }
-
-    let totalHeight = paddingTop + paddingBottom + linksHeight;
-    if (headerHeight) {
-      totalHeight += headerHeight;
-    }
-    if (headerHeight && linksHeight) {
-      totalHeight += columnGap;
-    }
-
-    totalHeight = Math.ceil(totalHeight);
-
-    const safeSpacing = Math.max(12, Math.round(viewportHeight * 0.015));
-    const availableHeight = Math.max(0, Math.round(viewportHeight - safeSpacing));
-    let targetHeight = totalHeight;
-    if (availableHeight && totalHeight > availableHeight) {
-      targetHeight = availableHeight;
-    }
-
-    if (!targetHeight || targetHeight <= 0) {
-      navContainer.style.removeProperty('--mobile-nav-max-height');
-      navContainer.style.removeProperty('--mobile-nav-height');
-      navContainer.classList.remove('mobile-nav--scrollable');
-      return;
-    }
-
-    navContainer.style.setProperty('--mobile-nav-max-height', `${targetHeight}px`);
-    navContainer.style.setProperty('--mobile-nav-height', `${targetHeight}px`);
-    const needsScroll = totalHeight - targetHeight > 1;
-    navContainer.classList.toggle('mobile-nav--scrollable', needsScroll);
-  };
 
   const focusableSelectors = [
     'a[href]',
@@ -805,8 +676,6 @@ function setupResponsiveNavigation() {
       }
     }
 
-    updateMobileNavHeight();
-
     const mapElement = document.getElementById('map');
     if (mapElement) {
       repositionMapControls(mapElement);
@@ -816,29 +685,6 @@ function setupResponsiveNavigation() {
   };
 
   setNavState(false);
-
-  if (typeof ResizeObserver === 'function') {
-    const resizeObserver = new ResizeObserver(() => updateMobileNavHeight());
-    resizeObserver.observe(navContainer);
-    if (links) {
-      resizeObserver.observe(links);
-    }
-  }
-
-  const handleViewportChange = () => updateMobileNavHeight();
-  window.addEventListener('resize', handleViewportChange);
-
-  if (window.visualViewport) {
-    window.visualViewport.addEventListener('resize', handleViewportChange);
-    window.visualViewport.addEventListener('scroll', handleViewportChange);
-  }
-
-  if (typeof MutationObserver === 'function') {
-    const navMutationObserver = new MutationObserver(updateMobileNavHeight);
-    navMutationObserver.observe(links, { childList: true, subtree: true });
-  }
-
-  updateMobileNavHeight();
 
   const closeNav = () => setNavState(false);
 
@@ -869,9 +715,6 @@ function setupResponsiveNavigation() {
     } else {
       setNavState(false);
     }
-
-    updateMobileNavHeight();
-    toggleBodyScroll(false);
   };
 
   if (typeof navMediaQuery.addEventListener === 'function') {
@@ -919,23 +762,6 @@ function setAccountMenuOpen(state, open) {
   }
   if (state.container) {
     state.container.classList.toggle('topbar__account--open', isOpen);
-  }
-
-  if (typeof window !== 'undefined') {
-    const realignOverlays = () => {
-      const mapElement = document.getElementById('map');
-      if (mapElement) {
-        repositionMapControls(mapElement);
-      } else {
-        applyLayoutOffsets(getControlOffset());
-      }
-    };
-
-    if (typeof requestAnimationFrame === 'function') {
-      requestAnimationFrame(realignOverlays);
-    } else {
-      setTimeout(realignOverlays, 0);
-    }
   }
 }
 
@@ -1411,20 +1237,6 @@ function bindOverlayDragging(overlay) {
   if (!overlay || overlay.dataset.draggableBound === 'true') return;
 
   const visualHandle = overlay.querySelector('[data-drag-handle]');
-  const computeHorizontalPeek = size => {
-    if (!Number.isFinite(size) || size <= 0) return 0;
-    const preferred = Math.round(size * 0.32);
-    const base = Math.max(108, Math.min(preferred, 184));
-    const maxVisible = Math.max(size - 24, Math.round(size * 0.75));
-    return Math.min(Math.max(base, 96), maxVisible);
-  };
-  const computeVerticalPeek = size => {
-    if (!Number.isFinite(size) || size <= 0) return 0;
-    const preferred = Math.round(size * 0.38);
-    const base = Math.max(88, Math.min(preferred, 152));
-    const maxVisible = Math.max(size - 28, Math.round(size * 0.78));
-    return Math.min(Math.max(base, 72), maxVisible);
-  };
 
   try {
     const computedStyle = window.getComputedStyle(overlay);
@@ -1449,8 +1261,7 @@ function bindOverlayDragging(overlay) {
   }
 
   const handlePointerDown = event => {
-    const pointerType = event.pointerType || 'mouse';
-    if (pointerType === 'mouse' && event.button !== 0) {
+    if (event.pointerType === 'mouse' && event.button !== 0) {
       return;
     }
 
@@ -1458,22 +1269,9 @@ function bindOverlayDragging(overlay) {
       return;
     }
 
-    if (isMobileViewport() && !pageAllowsMobileBodyDrag()) {
-      const handleTarget =
-        event.target && typeof event.target.closest === 'function'
-          ? event.target.closest('[data-drag-handle]')
-          : null;
-      if (!handleTarget || !overlay.contains(handleTarget)) {
-        return;
-      }
-    }
-
-    const scrollableAncestor =
-      event.target && event.target.closest && event.target.closest('[data-overlay-body]');
-    const scrollElement =
-      scrollableAncestor instanceof HTMLElement ? scrollableAncestor : null;
+    const scrollableAncestor = event.target && event.target.closest('[data-overlay-body]');
     const canScroll = Boolean(
-      scrollElement && scrollElement.scrollHeight - scrollElement.clientHeight > 2
+      scrollableAncestor && scrollableAncestor.scrollHeight > scrollableAncestor.clientHeight
     );
 
     const pointerId = event.pointerId;
@@ -1508,12 +1306,6 @@ function bindOverlayDragging(overlay) {
       if (initialEvent && typeof initialEvent.preventDefault === 'function') {
         initialEvent.preventDefault();
       }
-
-      try {
-        overlay.setPointerCapture(pointerId);
-      } catch (captureError) {
-        // Pointer capture may fail on unsupported browsers; ignore.
-      }
     };
 
     const cleanup = shouldReposition => {
@@ -1521,46 +1313,7 @@ function bindOverlayDragging(overlay) {
       window.removeEventListener('pointerup', endDrag);
       window.removeEventListener('pointercancel', endDrag);
 
-      try {
-        if (
-          typeof overlay.hasPointerCapture === 'function' &&
-          overlay.hasPointerCapture(pointerId)
-        ) {
-          overlay.releasePointerCapture(pointerId);
-        }
-      } catch (releaseError) {
-        // Non-blocking.
-      }
-
-      const snapToEdges = () => {
-        const liveRect = overlay.getBoundingClientRect();
-        const viewportWidth = window.innerWidth || document.documentElement.clientWidth || liveRect.right;
-        const viewportHeight = window.innerHeight || document.documentElement.clientHeight || liveRect.bottom;
-        const margin = 20;
-        const horizontalPeek = computeHorizontalPeek(liveRect.width);
-        const verticalPeek = computeVerticalPeek(liveRect.height);
-
-        let nextLeft = parseFloat(overlay.style.left) || liveRect.left;
-        let nextTop = parseFloat(overlay.style.top) || liveRect.top;
-
-        if (nextLeft <= margin) {
-          nextLeft = Math.min(margin, horizontalPeek - liveRect.width);
-        } else if (nextLeft + liveRect.width >= viewportWidth - margin) {
-          nextLeft = Math.max(viewportWidth - horizontalPeek, viewportWidth - liveRect.width - margin);
-        }
-
-        if (nextTop <= margin) {
-          nextTop = Math.min(margin, verticalPeek - liveRect.height);
-        } else if (nextTop + liveRect.height >= viewportHeight - margin) {
-          nextTop = Math.max(viewportHeight - verticalPeek, viewportHeight - liveRect.height - margin);
-        }
-
-        overlay.style.left = `${Math.round(nextLeft)}px`;
-        overlay.style.top = `${Math.round(nextTop)}px`;
-      };
-
       if (shouldReposition) {
-        snapToEdges();
         const mapElement = document.getElementById('map');
         if (mapElement) {
           repositionMapControls(mapElement);
@@ -1580,18 +1333,9 @@ function bindOverlayDragging(overlay) {
           return;
         }
 
-        if (canScroll && scrollElement && Math.abs(deltaY) >= Math.abs(deltaX)) {
-          const scrollTop = scrollElement.scrollTop;
-          const maxScroll = scrollElement.scrollHeight - scrollElement.clientHeight;
-          const movingDown = deltaY > 0;
-          const movingUp = deltaY < 0;
-          const canScrollDown = maxScroll - scrollTop > 1;
-          const canScrollUp = scrollTop > 1;
-
-          if ((movingDown && canScrollDown) || (movingUp && canScrollUp)) {
-            cleanup(false);
-            return;
-          }
+        if (canScroll && Math.abs(deltaY) > Math.abs(deltaX)) {
+          cleanup(false);
+          return;
         }
 
         startDrag(moveEvent);
@@ -1601,17 +1345,16 @@ function bindOverlayDragging(overlay) {
 
       const viewportWidth = window.innerWidth || document.documentElement.clientWidth || width;
       const viewportHeight = window.innerHeight || document.documentElement.clientHeight || height;
-      const margin = 20;
-      const horizontalPeek = computeHorizontalPeek(width);
-      const verticalPeek = computeVerticalPeek(height);
+      const margin = 12;
+      const edgeReveal = 4;
 
       let nextLeft = startLeft + deltaX;
       let nextTop = startTop + deltaY;
 
-      const minLeft = Math.min(margin, horizontalPeek - width);
-      const minTop = Math.min(margin, verticalPeek - height);
-      const maxLeft = Math.max(viewportWidth - width - margin, viewportWidth - horizontalPeek);
-      const maxTop = Math.max(viewportHeight - height - margin, viewportHeight - verticalPeek);
+      const minLeft = Math.min(margin, edgeReveal - width);
+      const minTop = Math.min(margin, edgeReveal - height);
+      const maxLeft = Math.max(viewportWidth - width - margin, viewportWidth - edgeReveal);
+      const maxTop = Math.max(viewportHeight - height - margin, viewportHeight - edgeReveal);
 
       nextLeft = Math.min(Math.max(nextLeft, minLeft), maxLeft);
       nextTop = Math.min(Math.max(nextTop, minTop), maxTop);
@@ -1677,13 +1420,6 @@ function setupSavedRoutesManager() {
     state.list.addEventListener('click', handleSavedRoutesListClick);
   }
 
-  if (!panel.dataset.authListenerBound) {
-    document.addEventListener('authchange', () => {
-      renderSavedRoutesList(state);
-    });
-    panel.dataset.authListenerBound = 'true';
-  }
-
   if (state.deleteSelect && state.deleteSelect.dataset.deleteSelectBound !== 'true') {
     state.deleteSelect.addEventListener('change', handleDeleteSelectChange);
     state.deleteSelect.dataset.deleteSelectBound = 'true';
@@ -1717,15 +1453,11 @@ function setupRouteSaveDialog() {
     inputs: {
       pointA: dialog.querySelector('[data-route-save-point-a]'),
       pointB: dialog.querySelector('[data-route-save-point-b]'),
-      notes: dialog.querySelector('[data-route-save-notes]'),
+      username: dialog.querySelector('[data-route-save-username]'),
+      homeTown: dialog.querySelector('[data-route-save-hometown]'),
       fareMin: dialog.querySelector('[data-route-save-fare-min]'),
       fareMax: dialog.querySelector('[data-route-save-fare-max]'),
     },
-    displays: {
-      username: dialog.querySelector('[data-route-save-username-display]'),
-      homeTown: dialog.querySelector('[data-route-save-hometown-display]'),
-    },
-    contributor: { username: '', homeTown: '' },
     resolver: null,
   };
 
@@ -1733,9 +1465,6 @@ function setupRouteSaveDialog() {
     dialog.hidden = true;
     dialog.setAttribute('aria-hidden', 'true');
     dialog.dataset.active = 'false';
-    if (routeSaveDialogState) {
-      routeSaveDialogState.contributor = { username: '', homeTown: '' };
-    }
   };
 
   const resetFeedback = () => {
@@ -1749,9 +1478,6 @@ function setupRouteSaveDialog() {
     routeSaveDialogState.feedback.textContent = message;
     routeSaveDialogState.feedback.classList.toggle('error', Boolean(isError));
   };
-
-  routeSaveDialogState.resetFeedback = resetFeedback;
-  routeSaveDialogState.showFeedback = showFeedback;
 
   const resolveDialog = result => {
     hideDialog();
@@ -1770,10 +1496,8 @@ function setupRouteSaveDialog() {
       const { inputs } = routeSaveDialogState;
       const pointA = inputs.pointA ? inputs.pointA.value.trim() : '';
       const pointB = inputs.pointB ? inputs.pointB.value.trim() : '';
-      const notes = inputs.notes ? inputs.notes.value.trim() : '';
-      const contributor = routeSaveDialogState.contributor || { username: '', homeTown: '' };
-      const username = typeof contributor.username === 'string' ? contributor.username.trim() : '';
-      const homeTown = typeof contributor.homeTown === 'string' ? contributor.homeTown.trim() : '';
+      const username = inputs.username ? inputs.username.value.trim() : '';
+      const homeTown = inputs.homeTown ? inputs.homeTown.value.trim() : '';
       const fareMinValueRaw = inputs.fareMin ? inputs.fareMin.value.trim() : '';
       const fareMaxValueRaw = inputs.fareMax ? inputs.fareMax.value.trim() : '';
 
@@ -1790,12 +1514,14 @@ function setupRouteSaveDialog() {
       }
 
       if (!username) {
-        showFeedback('Your registration profile is missing a username. Update it before saving routes.', true);
+        showFeedback('Enter your registered custom username.', true);
+        if (inputs.username) inputs.username.focus();
         return;
       }
 
       if (!homeTown) {
-        showFeedback('Your registration profile is missing a home town. Update it before saving routes.', true);
+        showFeedback('Enter the home town linked to your registration.', true);
+        if (inputs.homeTown) inputs.homeTown.focus();
         return;
       }
 
@@ -1818,7 +1544,6 @@ function setupRouteSaveDialog() {
         pointBName: pointB,
         username,
         homeTown,
-        notes,
         fareMin: fareMinValue,
         fareMax: fareMaxValue,
       });
@@ -1844,41 +1569,22 @@ function openRouteSaveDialog(defaults = {}) {
   const normalized = {
     pointAName: typeof defaults.pointAName === 'string' ? defaults.pointAName.trim() : '',
     pointBName: typeof defaults.pointBName === 'string' ? defaults.pointBName.trim() : '',
-    notes: typeof defaults.notes === 'string' ? defaults.notes.trim() : '',
+    username: typeof defaults.username === 'string' ? defaults.username.trim() : '',
+    homeTown: typeof defaults.homeTown === 'string' ? defaults.homeTown.trim() : '',
     fareMin: Number.isFinite(Number(defaults.fareMin)) ? Number(defaults.fareMin) : '',
     fareMax: Number.isFinite(Number(defaults.fareMax)) ? Number(defaults.fareMax) : '',
   };
 
-  const contributor = normalizeContributor(defaults.contributor || {});
-  state.contributor = contributor;
-
-  if (state.displays && state.displays.username) {
-    state.displays.username.textContent = contributor.username || '—';
-  }
-  if (state.displays && state.displays.homeTown) {
-    state.displays.homeTown.textContent = contributor.homeTown || '—';
-  }
-
   if (state.inputs.pointA) state.inputs.pointA.value = normalized.pointAName;
   if (state.inputs.pointB) state.inputs.pointB.value = normalized.pointBName;
-  if (state.inputs.notes) state.inputs.notes.value = normalized.notes;
+  if (state.inputs.username) state.inputs.username.value = normalized.username;
+  if (state.inputs.homeTown) state.inputs.homeTown.value = normalized.homeTown;
   if (state.inputs.fareMin) state.inputs.fareMin.value = normalized.fareMin === '' ? '' : normalized.fareMin;
   if (state.inputs.fareMax) state.inputs.fareMax.value = normalized.fareMax === '' ? '' : normalized.fareMax;
 
-  if (typeof state.resetFeedback === 'function') {
-    state.resetFeedback();
-  } else if (state.feedback) {
+  if (state.feedback) {
     state.feedback.textContent = '';
     state.feedback.classList.remove('error');
-  }
-
-  if (!contributor.username || !contributor.homeTown) {
-    if (typeof state.showFeedback === 'function') {
-      state.showFeedback(
-        'Account details incomplete. Update your username and home town before saving routes.',
-        true,
-      );
-    }
   }
 
   if (state.resolver) {
@@ -1891,7 +1597,7 @@ function openRouteSaveDialog(defaults = {}) {
   state.dialog.removeAttribute('aria-hidden');
   state.dialog.dataset.active = 'true';
 
-  const focusTarget = state.inputs.pointA;
+  const focusTarget = state.inputs.pointA || state.inputs.username;
   if (focusTarget && typeof focusTarget.focus === 'function') {
     window.requestAnimationFrame(() => {
       focusTarget.focus({ preventScroll: true });
@@ -1987,7 +1693,6 @@ function renderSavedRoutesList(state) {
 
   const sortedRoutes = sortRoutesForManager(state.routes, state.collator);
   populateRouteDeleteSelect(state, sortedRoutes);
-  const isLoggedIn = Boolean(getLoggedInUser());
 
   sortedRoutes.forEach(route => {
     const item = document.createElement('li');
@@ -2027,26 +1732,6 @@ function renderSavedRoutesList(state) {
     }
 
     item.appendChild(text);
-
-    const actions = document.createElement('div');
-    actions.className = 'route-adder-saved__actions';
-
-    const editButton = document.createElement('button');
-    editButton.type = 'button';
-    editButton.className = 'route-adder-saved__action';
-
-    if (isLoggedIn) {
-      editButton.textContent = 'Edit route';
-      editButton.dataset.routeAction = 'edit';
-      editButton.dataset.routeId = String(route.routeId);
-      editButton.setAttribute('aria-label', `Edit ${route.name || 'saved route'}`);
-    } else {
-      editButton.textContent = 'Sign in to edit';
-      editButton.dataset.routeAction = 'signin';
-    }
-
-    actions.appendChild(editButton);
-    item.appendChild(actions);
     list.appendChild(item);
   });
 }
@@ -2097,39 +1782,15 @@ function populateRouteDeleteSelect(state, routes) {
 function handleSavedRoutesListClick(event) {
   const target = event.target instanceof HTMLElement ? event.target.closest('[data-route-action]') : null;
   if (!target) return;
-
   const action = target.dataset.routeAction;
   const routeId = target.dataset.routeId;
-  const savedState = routeEditorState ? routeEditorState.savedRoutes : null;
-
-  if (action === 'signin') {
-    if (!openAccountMenu({ focus: 'signin', redirect: false })) {
-      window.location.href = '/registration.html#login';
+  if (action === 'delete' && routeId) {
+    const savedState = routeEditorState ? routeEditorState.savedRoutes : null;
+    if (!savedState) return;
+    const route = savedState.routes.find(entry => entry.routeId === routeId);
+    if (route) {
+      deleteSavedRouteRecord(route, target, savedState);
     }
-    return;
-  }
-
-  if (!savedState) {
-    return;
-  }
-
-  if (!routeId) {
-    if (action === 'edit') {
-      setEditorStatus(routeEditorState, 'Select a specific route to edit.');
-    }
-    return;
-  }
-
-  const route = savedState.routes.find(entry => String(entry.routeId) === String(routeId));
-  if (!route) return;
-
-  if (action === 'edit') {
-    loadRouteForEditing(route);
-    return;
-  }
-
-  if (action === 'delete') {
-    deleteSavedRouteRecord(route, target, savedState);
   }
 }
 
@@ -2266,8 +1927,6 @@ function setupRouteAdder(map) {
     savedRoutes: null,
     contributor: initialContributor,
     lastSaveDetails: null,
-    editingRouteId: null,
-    editingRouteName: '',
     polyline: new google.maps.Polyline({
       map,
       strokeColor: '#2563eb',
@@ -2392,8 +2051,6 @@ function startDrawingRoute(state) {
   state.mode = 'draw';
   state.path = [];
   state.snappedPath = [];
-  state.editingRouteId = null;
-  state.editingRouteName = '';
   initialiseRouteHistory(state);
   updateDraftPolyline(state);
   updateSnappedPolyline(state);
@@ -2449,8 +2106,6 @@ function deleteCurrentRoute(state) {
   state.mode = 'idle';
   state.path = [];
   state.snappedPath = [];
-  state.editingRouteId = null;
-  state.editingRouteName = '';
   initialiseRouteHistory(state);
   updateDraftPolyline(state);
   updateSnappedPolyline(state);
@@ -2601,110 +2256,6 @@ async function snapRouteToRoad(state) {
   }
 }
 
-function focusEditorMapOnPath(state, path) {
-  if (!state || !state.map || !Array.isArray(path) || path.length === 0) {
-    return;
-  }
-
-  try {
-    const bounds = new google.maps.LatLngBounds();
-    path.forEach(point => {
-      if (!point) return;
-      const lat = Number(point.lat);
-      const lng = Number(point.lng);
-      if (Number.isFinite(lat) && Number.isFinite(lng)) {
-        bounds.extend({ lat, lng });
-      }
-    });
-
-    if (!bounds.isEmpty()) {
-      state.map.fitBounds(bounds, getRouteFitPadding());
-    }
-  } catch (error) {
-    console.warn('Unable to focus editor map on saved route', error);
-  }
-}
-
-function loadRouteForEditing(route) {
-  if (!routeEditorState || !route) return;
-
-  const session = getAuthSession();
-  if (!session || !session.user) {
-    setEditorStatus(
-      routeEditorState,
-      'Sign in to edit saved routes. Use the account menu above to log in.',
-    );
-    if (!openAccountMenu({ focus: 'signin', redirect: false })) {
-      window.location.href = '/registration.html#login';
-    }
-    return;
-  }
-
-  const path = cloneCoordinateList(
-    Array.isArray(route.path) && route.path.length ? route.path : route.snappedPath || [],
-  );
-  const snappedPath = cloneCoordinateList(
-    Array.isArray(route.snappedPath) && route.snappedPath.length
-      ? route.snappedPath
-      : path,
-  );
-
-  if (!path.length && !snappedPath.length) {
-    setEditorStatus(
-      routeEditorState,
-      'This saved route does not include enough map data to edit.',
-    );
-    return;
-  }
-
-  const workingPath = path.length ? path : snappedPath;
-
-  routeEditorState.mode = 'edit';
-  routeEditorState.editingRouteId = route.routeId;
-  routeEditorState.editingRouteName = route.name || '';
-  routeEditorState.path = workingPath;
-  routeEditorState.snappedPath = snappedPath.length ? snappedPath : workingPath;
-
-  initialiseRouteHistory(routeEditorState);
-  routeEditorState.history = [cloneCoordinateList(routeEditorState.path)];
-  routeEditorState.redoStack = [];
-
-  const stops = Array.isArray(route.stops) ? route.stops : [];
-  const firstStop = stops[0] || null;
-  const lastStop = stops[stops.length - 1] || null;
-  const fare = route.fare || {};
-
-  routeEditorState.lastSaveDetails = {
-    pointAName: firstStop && typeof firstStop.name === 'string' ? firstStop.name : '',
-    pointBName:
-      lastStop && typeof lastStop.name === 'string' ? lastStop.name : firstStop && firstStop.name ? firstStop.name : '',
-    fareMin: Number.isFinite(Number(fare.min)) ? Number(fare.min) : '',
-    fareMax: Number.isFinite(Number(fare.max)) ? Number(fare.max) : '',
-    notes: typeof route.notes === 'string' ? route.notes : '',
-  };
-
-  const contributor = getRegisteredContributorDetails();
-  if (contributorHasDetails(contributor)) {
-    setRouteContributor(contributor);
-    routeEditorState.contributor = contributor;
-  }
-
-  updateDraftPolyline(routeEditorState);
-  updateSnappedPolyline(routeEditorState);
-
-  focusEditorMapOnPath(routeEditorState, routeEditorState.snappedPath.length ? routeEditorState.snappedPath : routeEditorState.path);
-  if (routeEditorState.map) {
-    repositionMapControls(routeEditorState.map.getDiv());
-  }
-
-  const routeLabel = route.name || 'Saved route';
-  setEditorStatus(
-    routeEditorState,
-    `Editing "${routeLabel}". Adjust the path or choose Save to update the shared directory.`,
-  );
-  updateEditorControls(routeEditorState);
-}
-
 async function saveCurrentRoute(state) {
   const workingPath = state.snappedPath.length > 1 ? state.snappedPath : state.path;
   if (workingPath.length < 2) {
@@ -2712,42 +2263,32 @@ async function saveCurrentRoute(state) {
     return;
   }
 
-  const session = getAuthSession();
-  const sessionUser = session && session.user ? session.user : null;
-  if (!sessionUser) {
-    setEditorStatus(state, 'Sign in to save taxi routes. Use the account menu above to log in.');
-    if (!openAccountMenu({ focus: 'signin', redirect: false })) {
-      window.location.href = '/registration.html#login';
+  const sessionUser = getLoggedInUser();
+  const stateContributor = normalizeContributor(state.contributor || {});
+  let contributorDefaults = stateContributor;
+
+  if (!contributorHasDetails(contributorDefaults)) {
+    const storedContributor = getRouteContributor();
+    if (contributorHasDetails(storedContributor)) {
+      contributorDefaults = normalizeContributor(storedContributor);
+    } else if (sessionUser) {
+      contributorDefaults = normalizeContributor({
+        username: sessionUser.username,
+        homeTown: sessionUser.homeTown,
+      });
+    } else {
+      contributorDefaults = normalizeContributor();
     }
-    return;
   }
-
-  const contributorDefaults = getRegisteredContributorDetails();
-  const hasContributorUsername = Boolean(contributorDefaults.username);
-  const hasContributorHomeTown = Boolean(contributorDefaults.homeTown);
-
-  if (!hasContributorUsername || !hasContributorHomeTown) {
-    setEditorStatus(
-      state,
-      'Complete your registration profile with a username and home town before saving routes.',
-    );
-    if (!openAccountMenu({ focus: 'profile', redirect: false })) {
-      window.location.href = '/registration.html#account';
-    }
-    return;
-  }
-
-  setRouteContributor(contributorDefaults);
-  state.contributor = { ...contributorDefaults };
 
   const previousDetails = state.lastSaveDetails || {};
   const dialogDefaults = {
     pointAName: previousDetails.pointAName || '',
     pointBName: previousDetails.pointBName || '',
-    notes: previousDetails.notes || '',
+    username: contributorDefaults.username,
+    homeTown: contributorDefaults.homeTown,
     fareMin: previousDetails.fareMin,
     fareMax: previousDetails.fareMax,
-    contributor: contributorDefaults,
   };
 
   const details = await openRouteSaveDialog(dialogDefaults);
@@ -2756,32 +2297,18 @@ async function saveCurrentRoute(state) {
     return;
   }
 
+  setRouteContributor({ username: details.username, homeTown: details.homeTown });
   state.contributor = { username: details.username, homeTown: details.homeTown };
-  state.lastSaveDetails = {
-    pointAName: details.pointAName,
-    pointBName: details.pointBName,
-    notes: details.notes || '',
-    fareMin: details.fareMin,
-    fareMax: details.fareMax,
-  };
+  state.lastSaveDetails = { ...details };
 
   const routeNameParts = [details.pointAName, details.pointBName].filter(part => part && part.trim());
   const generatedName = routeNameParts.length ? routeNameParts.join(' – ') : 'New Taxi Route';
-
-  const contributorNameParts = [
-    typeof sessionUser.firstName === 'string' ? sessionUser.firstName.trim() : '',
-    typeof sessionUser.lastName === 'string' ? sessionUser.lastName.trim() : '',
-  ].filter(Boolean);
-  const contributorDisplayName = contributorNameParts.join(' ').trim();
 
   const payload = {
     name: generatedName,
     gesture: '',
     province: '',
-    city: '',
-    pointAName: details.pointAName,
-    pointBName: details.pointBName,
-    notes: details.notes || '',
+    city: details.homeTown,
     fare: {
       min: Number.isFinite(details.fareMin) ? details.fareMin : 0,
       max: Number.isFinite(details.fareMax) ? details.fareMax : Number.isFinite(details.fareMin) ? details.fareMin : 0,
@@ -2795,24 +2322,18 @@ async function saveCurrentRoute(state) {
     snappedPath: cloneCoordinateList(state.snappedPath.length ? state.snappedPath : state.path),
     variations: [],
     addedBy: {
-      name: contributorDisplayName || details.username,
+      name: details.username,
       username: details.username,
       homeTown: details.homeTown,
     },
   };
 
-  const isEditingExisting = Boolean(state.editingRouteId);
-  const endpoint = isEditingExisting
-    ? `/api/routes/${encodeURIComponent(state.editingRouteId)}`
-    : '/api/routes';
-  const method = isEditingExisting ? 'PUT' : 'POST';
-
   setEditorBusy(state, true);
-  setEditorStatus(state, isEditingExisting ? 'Updating route...' : 'Saving route...');
+  setEditorStatus(state, 'Saving route...');
 
   try {
-    const response = await fetch(endpoint, {
-      method,
+    const response = await fetch('/api/routes', {
+      method: 'POST',
       headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
       body: JSON.stringify(payload),
     });
@@ -2820,20 +2341,15 @@ async function saveCurrentRoute(state) {
       const errorData = await response.json().catch(() => ({}));
       const message = errorData && errorData.message
         ? errorData.message
-        : isEditingExisting
-          ? 'Unable to update the route right now. Please try again.'
-          : 'Unable to save the route right now. Please try again.';
+        : 'Unable to save the route right now. Please try again.';
       setEditorStatus(state, message);
       return;
     }
     const saved = await response.json();
-    const actionVerb = isEditingExisting ? 'updated' : 'saved';
-    setEditorStatus(state, `Route "${saved.name || generatedName}" ${actionVerb} successfully.`);
+    setEditorStatus(state, `Route "${saved.name || generatedName}" saved successfully.`);
     state.mode = 'idle';
     state.path = [];
     state.snappedPath = [];
-    state.editingRouteId = null;
-    state.editingRouteName = '';
     initialiseRouteHistory(state);
     updateDraftPolyline(state);
     updateSnappedPolyline(state);
@@ -2841,17 +2357,9 @@ async function saveCurrentRoute(state) {
     if (routeEditorState && routeEditorState.savedRoutes) {
       loadSavedRoutesForEditor(routeEditorState.savedRoutes, { silent: true, force: true });
     }
-    if (typeof loadRoutesForFinder === 'function') {
-      loadRoutesForFinder();
-    }
   } catch (error) {
     console.error('Unable to save route', error);
-    setEditorStatus(
-      state,
-      isEditingExisting
-        ? 'Unable to update the route right now. Please try again.'
-        : 'Unable to save the route right now. Please try again.',
-    );
+    setEditorStatus(state, 'Unable to save the route right now. Please try again.');
   } finally {
     setEditorBusy(state, false);
   }
@@ -3960,18 +3468,15 @@ function normalizeRouteRecord(rawRoute) {
   const city = typeof rawRoute.city === 'string' && rawRoute.city.trim() ? rawRoute.city.trim() : 'Unspecified city';
   const path = cloneCoordinateList(Array.isArray(rawRoute.path) ? rawRoute.path : []);
   const snappedPath = cloneCoordinateList(Array.isArray(rawRoute.snappedPath) ? rawRoute.snappedPath : []);
-  const rawStops = Array.isArray(rawRoute.stops) ? rawRoute.stops : [];
-  const stops = rawStops
-    .map(stop => ({
-      name: typeof stop.name === 'string' && stop.name.trim() ? stop.name.trim() : 'Stop',
-      lat: Number(stop.lat),
-      lng: Number(stop.lng),
-    }))
-    .filter(stop => Number.isFinite(stop.lat) && Number.isFinite(stop.lng));
-  const fallbackPointA = rawStops.length && typeof rawStops[0].name === 'string' ? rawStops[0].name.trim() : '';
-  const fallbackPointB = rawStops.length && typeof rawStops[rawStops.length - 1].name === 'string'
-    ? rawStops[rawStops.length - 1].name.trim()
-    : fallbackPointA;
+  const stops = Array.isArray(rawRoute.stops)
+    ? rawRoute.stops
+        .map(stop => ({
+          name: typeof stop.name === 'string' && stop.name.trim() ? stop.name.trim() : 'Stop',
+          lat: Number(stop.lat),
+          lng: Number(stop.lng),
+        }))
+        .filter(stop => Number.isFinite(stop.lat) && Number.isFinite(stop.lng))
+    : [];
   const fare = rawRoute.fare
     ? {
         min: Number(rawRoute.fare.min),
@@ -3992,13 +3497,6 @@ function normalizeRouteRecord(rawRoute) {
     : { name: '', username: '', homeTown: '' };
   const createdAt = typeof rawRoute.createdAt === 'string' ? rawRoute.createdAt : '';
   const updatedAt = typeof rawRoute.updatedAt === 'string' ? rawRoute.updatedAt : '';
-  const pointAName = typeof rawRoute.pointAName === 'string' && rawRoute.pointAName.trim()
-    ? rawRoute.pointAName.trim()
-    : fallbackPointA;
-  const pointBName = typeof rawRoute.pointBName === 'string' && rawRoute.pointBName.trim()
-    ? rawRoute.pointBName.trim()
-    : fallbackPointB;
-  const notes = typeof rawRoute.notes === 'string' ? rawRoute.notes.trim() : '';
 
   return {
     ...rawRoute,
@@ -4009,9 +3507,6 @@ function normalizeRouteRecord(rawRoute) {
     path,
     snappedPath,
     stops,
-    pointAName,
-    pointBName,
-    notes,
     fare,
     frequencyPerHour: Number.isFinite(frequency) ? frequency : null,
     nameLower: name.toLowerCase(),
@@ -4116,18 +3611,6 @@ function renderRouteDetails(route, options = {}) {
   const gestureText = route.gesture ? escapeHtml(route.gesture) : 'Not specified';
   const stopsMarkup = buildStopsMarkup(route.stops);
   const variationsCount = Array.isArray(route.variations) ? route.variations.length : 0;
-  const startNameRaw = typeof route.pointAName === 'string' && route.pointAName.trim()
-    ? route.pointAName.trim()
-    : Array.isArray(route.stops) && route.stops.length
-      ? route.stops[0].name
-      : '';
-  const endNameRaw = typeof route.pointBName === 'string' && route.pointBName.trim()
-    ? route.pointBName.trim()
-    : Array.isArray(route.stops) && route.stops.length
-      ? route.stops[route.stops.length - 1].name
-      : '';
-  const pointAValue = escapeHtml(startNameRaw || 'Unspecified');
-  const pointBValue = escapeHtml(endNameRaw || 'Unspecified');
   const contributorUsername = route.addedBy && route.addedBy.username ? route.addedBy.username : '';
   const contributorHomeTown = route.addedBy && route.addedBy.homeTown ? route.addedBy.homeTown : '';
   let contributorMarkup = '';
@@ -4149,15 +3632,12 @@ function renderRouteDetails(route, options = {}) {
   const drawnPathMarkup = buildPathSection('Drawn path', route.path);
   const snappedPathMarkup = buildPathSection('Snapped path', route.snappedPath);
   const rawDataMarkup = buildRawRouteDataSection(route);
-  const notesMarkup = buildNotesMarkup(route.notes);
 
   container.innerHTML = `
     <h2>${escapeHtml(route.name)}</h2>
     <ul class="route-details__meta">
       <li><strong>Province:</strong> ${escapeHtml(route.province || 'Unspecified')}</li>
       <li><strong>City:</strong> ${escapeHtml(route.city || 'Unspecified')}</li>
-      <li><strong>Route point A:</strong> ${pointAValue}</li>
-      <li><strong>Route point B:</strong> ${pointBValue}</li>
       <li><strong>Fare:</strong> ${fareText}</li>
       <li><strong>Gesture:</strong> ${gestureText}</li>
       <li><strong>Frequency:</strong> ${frequencyMarkup}</li>
@@ -4167,7 +3647,6 @@ function renderRouteDetails(route, options = {}) {
       ${createdAtMarkup}
       ${updatedAtMarkup}
     </ul>
-    ${notesMarkup}
     ${rushHoursMarkup}
     ${quietHoursMarkup}
     ${variationsMarkup}
@@ -4224,21 +3703,6 @@ function buildTimeSection(label, values, emptyMessage) {
     <div class="route-details__section">
       <strong>${escapeHtml(label)}</strong>
       <ul class="route-details__chips">${chips}</ul>
-    </div>
-  `;
-}
-
-function buildNotesMarkup(notes) {
-  const text = typeof notes === 'string' ? notes.trim() : '';
-  if (!text) {
-    return '';
-  }
-
-  const formatted = escapeHtml(text).replace(/\r?\n/g, '<br />');
-  return `
-    <div class="route-details__section">
-      <strong>Notes &amp; comments</strong>
-      <p>${formatted}</p>
     </div>
   `;
 }

--- a/client/app.js
+++ b/client/app.js
@@ -569,6 +569,10 @@ async function fallbackToIpLocation(map) {
 function getControlOffset() {
   const topbar = document.getElementById('topbar');
   const navHeight = topbar ? topbar.getBoundingClientRect().height : 56;
+  const root = document.documentElement;
+  if (root) {
+    root.style.setProperty('--topbar-height', `${Math.round(navHeight)}px`);
+  }
   let offset = navHeight + 12;
   const banner = document.querySelector('.delivery-banner');
   if (banner && banner.isConnected) {

--- a/client/community.html
+++ b/client/community.html
@@ -9,7 +9,7 @@
 </head>
 <body class="page map-background page-community">
     <div id="topbar" data-nav-open="false">
-      <a href="/" class="topbar__brand">iTaxi-Finder</a>
+      <a href="/index.html" class="topbar__brand">iTaxi-Finder</a>
       <button type="button" class="topbar__menu" aria-expanded="false" aria-controls="topbar-navigation" data-nav-toggle>
       <span class="topbar__menu-icon" aria-hidden="true">
         <span class="topbar__menu-line"></span>

--- a/client/community.html
+++ b/client/community.html
@@ -47,6 +47,12 @@
   >
     <div class="overlay-drag-handle overlay-drag-handle--floating" data-drag-handle aria-hidden="true"></div>
     <h1 id="community-heading">Community noticeboard</h1>
+    <div class="social-links">
+      <a href="https://www.facebook.com" target="_blank" rel="noreferrer">Facebook</a>
+      <a href="https://www.instagram.com" target="_blank" rel="noreferrer">Instagram</a>
+      <a href="https://www.tiktok.com" target="_blank" rel="noreferrer">TikTok</a>
+      <a href="https://www.twitter.com" target="_blank" rel="noreferrer">X</a>
+    </div>
     <p>Explore township-specific hubs for announcements, lost-and-found alerts, and route news. Each page is a canvas for local
       operators, commuters, and sponsors to share updates anchored to the live map.</p>
     <div class="community-grid">
@@ -100,12 +106,6 @@
     <a href="/community/kwanobuhle.html">KwaNobuhle</a>
     <a href="/community/thembalethu.html">Thembalethu</a>
     <a href="/community/kwanonqaba.html">KwaNonqaba</a>
-    </div>
-    <div class="social-links">
-      <a href="https://www.facebook.com" target="_blank" rel="noreferrer">Facebook</a>
-      <a href="https://www.instagram.com" target="_blank" rel="noreferrer">Instagram</a>
-      <a href="https://www.tiktok.com" target="_blank" rel="noreferrer">TikTok</a>
-      <a href="https://www.twitter.com" target="_blank" rel="noreferrer">X</a>
     </div>
   </main>
   <div id="map"></div>

--- a/client/delivery.html
+++ b/client/delivery.html
@@ -9,7 +9,7 @@
 </head>
 <body class="page map-background page-delivery">
     <div id="topbar" data-nav-open="false">
-      <a href="/" class="topbar__brand">iTaxi-Finder</a>
+      <a href="/index.html" class="topbar__brand">iTaxi-Finder</a>
       <button type="button" class="topbar__menu" aria-expanded="false" aria-controls="topbar-navigation" data-nav-toggle>
       <span class="topbar__menu-icon" aria-hidden="true">
         <span class="topbar__menu-line"></span>

--- a/client/delivery.html
+++ b/client/delivery.html
@@ -41,9 +41,7 @@
       <div class="mobile-nav__backdrop" data-nav-backdrop></div>
     </div>
   <div class="delivery-banner" role="note">
-    <span>“The taxi industry already has the infrastructure and building blocks to facilitate a parcel delivery service, all that
-      remains is a central platform to manage, track and coordinate all order requests and the handovers they require along the
-      way.”</span>
+    <span>The Delivery feature is still under development.</span>
     <button type="button" data-dismiss-banner aria-label="Dismiss Delivery Extenda banner">Hide</button>
   </div>
   <main

--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,7 @@
 </head>
 <body class="page map-background page-home">
     <div id="topbar" data-nav-open="false">
-      <a href="/" class="topbar__brand" aria-current="page">iTaxi-Finder</a>
+      <a href="/index.html" class="topbar__brand" aria-current="page">iTaxi-Finder</a>
       <button type="button" class="topbar__menu" aria-expanded="false" aria-controls="topbar-navigation" data-nav-toggle>
       <span class="topbar__menu-icon" aria-hidden="true">
         <span class="topbar__menu-line"></span>

--- a/client/registration.html
+++ b/client/registration.html
@@ -9,7 +9,7 @@
 </head>
 <body class="page map-background page-registration">
     <div id="topbar" data-nav-open="false">
-      <a href="/" class="topbar__brand">iTaxi-Finder</a>
+      <a href="/index.html" class="topbar__brand">iTaxi-Finder</a>
       <button type="button" class="topbar__menu" aria-expanded="false" aria-controls="topbar-navigation" data-nav-toggle>
       <span class="topbar__menu-icon" aria-hidden="true">
         <span class="topbar__menu-line"></span>

--- a/client/registration.html
+++ b/client/registration.html
@@ -49,6 +49,21 @@
     <h1 id="registration-heading">Join the iTaxi-Finder network</h1>
     <p>Register your role to unlock tools tailored for collectors, drivers, depot owners, and partners. We capture just enough
       information to verify your business, route alignment, and preferred contact channels before activating your workspace.</p>
+    <form id="login" class="registration-login" data-static-form data-login-form>
+      <fieldset>
+        <legend>Already registered? Sign in</legend>
+        <label>
+          Username
+          <input type="text" name="username" autocomplete="username" minlength="3" required />
+        </label>
+        <label>
+          Password
+          <input type="password" name="password" autocomplete="current-password" minlength="4" required />
+        </label>
+        <p class="registration-error" data-login-error hidden role="alert"></p>
+        <button type="submit" class="cta secondary">Sign in</button>
+      </fieldset>
+    </form>
     <section class="registration-account" aria-live="polite">
       <p class="registration-account__status" data-auth-status>Not signed in.</p>
       <button type="button" class="cta secondary registration-account__signout" data-logout-button hidden>Sign out</button>
@@ -125,21 +140,6 @@
       <div class="registration-owner-actions" data-registration-actions>
         <button type="submit" class="cta">Submit registration</button>
       </div>
-    </form>
-    <form class="registration-login" data-static-form data-login-form>
-      <fieldset>
-        <legend>Already registered? Sign in</legend>
-        <label>
-          Username
-          <input type="text" name="username" autocomplete="username" minlength="3" required />
-        </label>
-        <label>
-          Password
-          <input type="password" name="password" autocomplete="current-password" minlength="4" required />
-        </label>
-        <p class="registration-error" data-login-error hidden role="alert"></p>
-        <button type="submit" class="cta secondary">Sign in</button>
-      </fieldset>
     </form>
     <section
       id="registration-success"

--- a/client/route-adder.html
+++ b/client/route-adder.html
@@ -9,7 +9,7 @@
 </head>
 <body class="page map-background page-route-adder">
     <div id="topbar" data-nav-open="false">
-      <a href="/" class="topbar__brand">iTaxi-Finder</a>
+      <a href="/index.html" class="topbar__brand">iTaxi-Finder</a>
       <button type="button" class="topbar__menu" aria-expanded="false" aria-controls="topbar-navigation" data-nav-toggle>
       <span class="topbar__menu-icon" aria-hidden="true">
         <span class="topbar__menu-line"></span>

--- a/client/route-adder.html
+++ b/client/route-adder.html
@@ -136,27 +136,19 @@
             data-route-save-point-b
           />
         </li>
-        <li>
-          <label for="route-save-username">Custom username</label>
-          <input
-            id="route-save-username"
-            type="text"
-            name="username"
-            autocomplete="username"
-            required
-            data-route-save-username
-          />
-        </li>
-        <li>
-          <label for="route-save-hometown">Home town</label>
-          <input
-            id="route-save-hometown"
-            type="text"
-            name="homeTown"
-            autocomplete="address-level2"
-            required
-            data-route-save-hometown
-          />
+        <li class="route-save-dialog__contributor" data-route-save-contributor>
+          <span class="route-save-dialog__contributor-heading">Registered contributor</span>
+          <p class="route-save-dialog__contributor-line">
+            <strong>Username:</strong>
+            <span data-route-save-username-display>—</span>
+          </p>
+          <p class="route-save-dialog__contributor-line">
+            <strong>Home town:</strong>
+            <span data-route-save-hometown-display>—</span>
+          </p>
+          <p class="route-save-dialog__contributor-hint">
+            Update your account profile to change these details.
+          </p>
         </li>
         <li>
           <label for="route-save-minfare">Minimum fare price (ZAR)</label>

--- a/client/route-adder.html
+++ b/client/route-adder.html
@@ -136,6 +136,16 @@
             data-route-save-point-b
           />
         </li>
+        <li>
+          <label for="route-save-notes">Notes and comments (optional)</label>
+          <textarea
+            id="route-save-notes"
+            name="notes"
+            rows="3"
+            placeholder="Share any timing, safety or transfer tips commuters should know"
+            data-route-save-notes
+          ></textarea>
+        </li>
         <li class="route-save-dialog__contributor" data-route-save-contributor>
           <span class="route-save-dialog__contributor-heading">Registered contributor</span>
           <p class="route-save-dialog__contributor-line">

--- a/client/route-finder.html
+++ b/client/route-finder.html
@@ -9,7 +9,7 @@
 </head>
 <body class="page map-background page-route-finder">
     <div id="topbar" data-nav-open="false">
-      <a href="/" class="topbar__brand">iTaxi-Finder</a>
+      <a href="/index.html" class="topbar__brand">iTaxi-Finder</a>
       <button type="button" class="topbar__menu" aria-expanded="false" aria-controls="topbar-navigation" data-nav-toggle>
       <span class="topbar__menu-icon" aria-hidden="true">
         <span class="topbar__menu-line"></span>

--- a/client/styles.css
+++ b/client/styles.css
@@ -5,6 +5,10 @@
   --overlay-minimized-height: clamp(48px, 9vh, 68px);
   --overlay-toggle-size: clamp(32px, 8vw, 40px);
   --overlay-handle-width: clamp(30px, 9vw, 48px);
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
 }
 
 html, body {
@@ -41,6 +45,7 @@ body.map-background {
 }
 
 #topbar {
+  --topbar-padding-inline: clamp(18px, 6vw, 28px);
   position: fixed;
   top: 0;
   left: 0;
@@ -52,7 +57,9 @@ body.map-background {
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  padding: 12px clamp(18px, 6vw, 28px);
+  padding: calc(12px + var(--safe-area-top)) var(--topbar-padding-inline);
+  padding-left: calc(var(--topbar-padding-inline) + var(--safe-area-left));
+  padding-right: calc(var(--topbar-padding-inline) + var(--safe-area-right));
   box-sizing: border-box;
   z-index: 1200;
   font-weight: 600;
@@ -63,6 +70,8 @@ body.map-background {
   border-left: 1px solid rgba(148, 163, 184, 0.2);
   border-right: 1px solid rgba(148, 163, 184, 0.2);
   border-bottom: 1px solid rgba(148, 163, 184, 0.32);
+  flex-wrap: wrap;
+  align-content: center;
 }
 
 #topbar a {
@@ -231,12 +240,25 @@ body.map-background {
 }
 
 @media (max-width: 899px) {
+  #topbar {
+    row-gap: 6px;
+  }
+
   .topbar__account {
-    width: 100%;
     order: 3;
+    flex: 1 0 100%;
+    width: calc(100% + (2 * var(--topbar-padding-inline)));
+    margin-left: calc(-1 * var(--topbar-padding-inline));
+    margin-right: calc(-1 * var(--topbar-padding-inline));
+    padding: 8px calc(var(--topbar-padding-inline) + var(--safe-area-right))
+      calc(14px + var(--safe-area-bottom))
+      calc(var(--topbar-padding-inline) + var(--safe-area-left));
+    box-sizing: border-box;
     justify-content: flex-start;
-    padding: 6px 0 12px;
-    border-top: 1px solid rgba(15, 23, 42, 0.16);
+    border-top: 1px solid rgba(15, 23, 42, 0.14);
+    background: linear-gradient(180deg, rgba(248, 250, 252, 0.82), rgba(226, 232, 240, 0.68));
+    border-bottom-left-radius: 22px;
+    border-bottom-right-radius: 22px;
   }
 
   .topbar__account-toggle {
@@ -246,9 +268,17 @@ body.map-background {
 
   .topbar__account-menu {
     position: static;
-    width: 100%;
-    margin-top: 12px;
+    width: calc(100% + (2 * var(--topbar-padding-inline)));
+    margin: 12px calc(-1 * var(--topbar-padding-inline)) 0;
+    padding: 16px calc(var(--topbar-padding-inline) + var(--safe-area-right)) 20px
+      calc(var(--topbar-padding-inline) + var(--safe-area-left));
     box-shadow: none;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    max-height: none;
+    height: auto;
   }
 
   .topbar__account-details {
@@ -543,11 +573,15 @@ body.nav-open {
 
 @media (min-width: 900px) {
   #topbar {
-    padding: 16px clamp(32px, 5vw, 48px);
+    --topbar-padding-inline: clamp(32px, 5vw, 48px);
+    padding: calc(16px + var(--safe-area-top)) var(--topbar-padding-inline);
+    padding-left: calc(var(--topbar-padding-inline) + var(--safe-area-left));
+    padding-right: calc(var(--topbar-padding-inline) + var(--safe-area-right));
     gap: 20px;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     box-shadow: 0 20px 40px rgba(15, 23, 42, 0.16);
+    flex-wrap: nowrap;
   }
 
   .topbar__menu {

--- a/client/styles.css
+++ b/client/styles.css
@@ -2219,6 +2219,40 @@ body.page-route-finder #map::after {
     right: 10px;
     box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
   }
+
+  body.page-home,
+  body.page-delivery,
+  body.page-community,
+  body.page-registration,
+  body.page-about {
+    --overlay-panel-top: 76px;
+    --overlay-panel-max-height: calc(100vh - 104px);
+  }
+
+  body.page-home .content-panel[data-draggable-overlay],
+  body.page-delivery .content-panel[data-draggable-overlay],
+  body.page-community .content-panel[data-draggable-overlay],
+  body.page-registration .content-panel[data-draggable-overlay],
+  body.page-about .content-panel[data-draggable-overlay] {
+    display: flex;
+    flex-direction: column;
+    width: min(360px, calc(100% - 24px));
+    max-height: min(88vh, calc(var(--overlay-panel-max-height) + 48px));
+    padding: 26px 24px 30px;
+    touch-action: pan-y;
+    overflow: hidden;
+  }
+
+  body.page-home .content-panel[data-draggable-overlay] [data-overlay-body],
+  body.page-delivery .content-panel[data-draggable-overlay] [data-overlay-body],
+  body.page-community .content-panel[data-draggable-overlay] [data-overlay-body],
+  body.page-registration .content-panel[data-draggable-overlay] [data-overlay-body],
+  body.page-about .content-panel[data-draggable-overlay] [data-overlay-body] {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-right: 4px;
+  }
 }
 
 @media (max-width: 480px) {
@@ -2317,5 +2351,22 @@ body.page-route-finder #map::after {
   .overlay-toggle {
     top: 8px;
     right: 8px;
+  }
+
+  body.page-home .content-panel[data-draggable-overlay],
+  body.page-delivery .content-panel[data-draggable-overlay],
+  body.page-community .content-panel[data-draggable-overlay],
+  body.page-registration .content-panel[data-draggable-overlay],
+  body.page-about .content-panel[data-draggable-overlay] {
+    width: min(340px, calc(100% - 20px));
+    padding: 24px 20px 28px;
+  }
+
+  body.page-home .content-panel[data-draggable-overlay] [data-overlay-body],
+  body.page-delivery .content-panel[data-draggable-overlay] [data-overlay-body],
+  body.page-community .content-panel[data-draggable-overlay] [data-overlay-body],
+  body.page-registration .content-panel[data-draggable-overlay] [data-overlay-body],
+  body.page-about .content-panel[data-draggable-overlay] [data-overlay-body] {
+    padding-right: 2px;
   }
 }

--- a/client/styles.css
+++ b/client/styles.css
@@ -724,6 +724,7 @@ body.nav-open {
   padding-top: 18px;
   font-size: 0.95rem;
   line-height: 1.6;
+  overflow-wrap: anywhere;
 }
 
 .route-details h2 {
@@ -1106,7 +1107,10 @@ body.nav-open {
   backdrop-filter: blur(6px);
   box-sizing: border-box;
   pointer-events: auto;
-  overflow: visible;
+  display: flex;
+  flex-direction: column;
+  max-height: var(--overlay-panel-max-height);
+  overflow: hidden;
   touch-action: none;
   cursor: grab;
 }
@@ -1182,6 +1186,14 @@ body.nav-open {
   touch-action: pan-y;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.overlay-panel > [data-drag-handle],
+.overlay-panel > [data-overlay-summary],
+.overlay-panel > [data-overlay-toggle] {
+  flex-shrink: 0;
 }
 
 .overlay-toggle {

--- a/client/styles.css
+++ b/client/styles.css
@@ -259,6 +259,9 @@ body.map-background {
     background: linear-gradient(180deg, rgba(248, 250, 252, 0.82), rgba(226, 232, 240, 0.68));
     border-bottom-left-radius: 22px;
     border-bottom-right-radius: 22px;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
   }
 
   .topbar__account-toggle {
@@ -279,6 +282,8 @@ body.map-background {
     border-bottom: none;
     max-height: none;
     height: auto;
+    min-width: 0;
+    max-width: none;
   }
 
   .topbar__account-details {

--- a/client/styles.css
+++ b/client/styles.css
@@ -143,12 +143,12 @@ body.map-background {
 
 .topbar__account-menu {
   position: absolute;
-  top: calc(100% + 10px);
+  top: calc(100% + 8px);
   right: 0;
-  min-width: 240px;
+  min-width: 260px;
   max-width: 320px;
-  padding: 16px;
-  border-radius: 16px;
+  padding: 18px 20px 20px;
+  border-radius: 20px;
   background: rgba(255, 255, 255, 0.96);
   backdrop-filter: blur(12px);
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
@@ -409,28 +409,23 @@ body.nav-open {
   position: fixed;
   top: 0;
   right: 0;
-  bottom: auto;
-  --mobile-nav-max-height: 100dvh;
-  --mobile-nav-height: auto;
-  max-height: min(100dvh, var(--mobile-nav-max-height));
-  height: var(--mobile-nav-height, auto);
-  width: min(340px, 84vw);
+  bottom: 0;
+  width: min(340px, 82vw);
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: calc(env(safe-area-inset-top, 0) + 36px) clamp(20px, 6vw, 28px) calc(env(safe-area-inset-bottom, 0) + 28px);
+  gap: 20px;
+  padding: clamp(96px, 20vh, 140px) clamp(22px, 6vw, 32px) 28px;
   background: rgba(255, 255, 255, 0.96);
   backdrop-filter: blur(18px);
   box-shadow: -28px 0 60px rgba(15, 23, 42, 0.25);
-  border-top-left-radius: 26px;
-  border-bottom-left-radius: 26px;
+  border-top-left-radius: 28px;
+  border-bottom-left-radius: 28px;
   transform: translateX(110%);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
   transition: transform 0.32s ease, opacity 0.32s ease, visibility 0.32s ease;
-  overflow-y: hidden;
-  box-sizing: border-box;
+  overflow-y: auto;
   scrollbar-gutter: stable;
   z-index: 1300;
 }
@@ -442,26 +437,21 @@ body.nav-open {
   pointer-events: auto;
 }
 
-.mobile-nav--scrollable {
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
 .mobile-nav__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.1);
 }
 
 .mobile-nav__title {
-  font-size: 0.72rem;
+  font-size: 0.75rem;
   font-weight: 700;
-  letter-spacing: 0.3em;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.7);
+  color: rgba(15, 23, 42, 0.68);
 }
 
 .mobile-nav__close {
@@ -524,17 +514,6 @@ body.nav-open {
   z-index: 1250;
 }
 
-#topbar[data-nav-mode='desktop'] .mobile-nav {
-  --mobile-nav-height: auto;
-  max-height: none;
-  height: auto;
-  overflow: visible;
-}
-
-#topbar[data-nav-mode='desktop'] .mobile-nav__backdrop {
-  display: none !important;
-}
-
 #topbar[data-nav-open="true"] .mobile-nav__backdrop {
   opacity: 1;
   visibility: visible;
@@ -544,7 +523,7 @@ body.nav-open {
 .topbar__links {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 16px;
   margin: 0;
   padding: 12px 0 0;
 }
@@ -555,7 +534,7 @@ body.nav-open {
   background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.08));
   color: #0f172a;
   border-radius: 18px;
-  padding: 12px 16px;
+  padding: 14px 18px;
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.1);
 }
 
@@ -564,17 +543,26 @@ body.nav-open {
   outline-offset: 4px;
 }
 
+.topbar__links a::after {
+  content: '\u203A';
+  font-size: 1rem;
+  opacity: 0.55;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.topbar__links a:hover::after,
+.topbar__links a:focus-visible::after {
+  transform: translateX(4px);
+  opacity: 0.85;
+}
+
 @media (min-width: 900px) {
   #topbar {
-    --topbar-padding-inline: clamp(32px, 5vw, 48px);
-    padding: calc(16px + var(--safe-area-top)) var(--topbar-padding-inline);
-    padding-left: calc(var(--topbar-padding-inline) + var(--safe-area-left));
-    padding-right: calc(var(--topbar-padding-inline) + var(--safe-area-right));
+    padding: 18px 40px;
     gap: 20px;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.16);
-    flex-wrap: nowrap;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
   }
 
   .topbar__menu {
@@ -596,9 +584,6 @@ body.nav-open {
     backdrop-filter: none;
     box-shadow: none;
     border-radius: 0;
-    height: auto;
-    max-height: none;
-    min-height: 0;
     overflow: visible;
   }
 
@@ -725,7 +710,6 @@ body.nav-open {
   padding-top: 18px;
   font-size: 0.95rem;
   line-height: 1.6;
-  overflow-wrap: anywhere;
 }
 
 .route-details h2 {
@@ -925,48 +909,6 @@ body.nav-open {
   flex: 1 1 auto;
 }
 
-.route-adder-saved__actions {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  flex: 0 0 auto;
-}
-
-.route-adder-saved__action {
-  appearance: none;
-  border: 1px solid rgba(37, 99, 235, 0.45);
-  background: rgba(37, 99, 235, 0.08);
-  color: #1d4ed8;
-  font-weight: 600;
-  font-size: 0.85rem;
-  padding: 6px 14px;
-  border-radius: 999px;
-  cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-  text-align: center;
-}
-
-.route-adder-saved__action:hover,
-.route-adder-saved__action:focus {
-  outline: none;
-  background: rgba(37, 99, 235, 0.18);
-  border-color: rgba(37, 99, 235, 0.6);
-  color: #1e3a8a;
-}
-
-.route-adder-saved__action:focus-visible {
-  outline: 2px solid rgba(37, 99, 235, 0.45);
-  outline-offset: 2px;
-}
-
-.route-adder-saved__action[disabled] {
-  cursor: not-allowed;
-  opacity: 0.6;
-  background: rgba(148, 163, 184, 0.2);
-  border-color: rgba(148, 163, 184, 0.45);
-  color: rgba(71, 85, 105, 0.9);
-}
-
 .route-adder-saved__item-name {
   display: block;
   font-weight: 600;
@@ -984,6 +926,12 @@ body.nav-open {
   font-size: 0.8rem;
   color: rgba(37, 99, 235, 0.75);
   margin-top: 4px;
+}
+
+.route-adder-saved__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .route-adder-saved__empty {
@@ -1015,10 +963,6 @@ body.nav-open {
   z-index: 1200;
 }
 
-.route-save-dialog[hidden] {
-  display: none !important;
-}
-
 .route-save-dialog__form {
   display: grid;
   gap: 16px;
@@ -1046,38 +990,6 @@ body.nav-open {
 .route-save-dialog__list label {
   font-weight: 600;
   color: rgba(15, 23, 42, 0.85);
-}
-
-.route-save-dialog__contributor {
-  list-style: none;
-  background: rgba(37, 99, 235, 0.08);
-  border: 1px solid rgba(37, 99, 235, 0.25);
-  border-radius: 12px;
-  padding: 14px 16px;
-  margin-top: 4px;
-}
-
-.route-save-dialog__contributor-heading {
-  font-weight: 600;
-  color: #1d4ed8;
-  margin-bottom: 6px;
-}
-
-.route-save-dialog__contributor-line {
-  margin: 2px 0;
-  font-size: 0.9rem;
-  color: rgba(15, 23, 42, 0.8);
-}
-
-.route-save-dialog__contributor-line strong {
-  font-weight: 600;
-  color: rgba(30, 64, 175, 0.95);
-}
-
-.route-save-dialog__contributor-hint {
-  margin: 8px 0 0;
-  font-size: 0.8rem;
-  color: rgba(71, 85, 105, 0.85);
 }
 
 .route-save-dialog__list input {
@@ -1180,16 +1092,7 @@ body.nav-open {
   backdrop-filter: blur(6px);
   box-sizing: border-box;
   pointer-events: auto;
-  display: flex;
-  flex-direction: column;
-  max-height: var(--overlay-panel-max-height);
-  overflow: hidden;
-  touch-action: none;
-  cursor: grab;
-}
-
-.overlay-panel:active {
-  cursor: grabbing;
+  overflow: visible;
 }
 
 .overlay-panel.route-adder-saved,
@@ -1250,23 +1153,7 @@ body.nav-open {
 }
 
 .overlay-body {
-  display: block;
-  width: 100%;
-  min-height: 0;
-}
-
-[data-overlay-body] {
-  touch-action: pan-y;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  flex: 1 1 auto;
-  min-height: 0;
-}
-
-.overlay-panel > [data-drag-handle],
-.overlay-panel > [data-overlay-summary],
-.overlay-panel > [data-overlay-toggle] {
-  flex-shrink: 0;
+  display: contents;
 }
 
 .overlay-toggle {
@@ -1550,9 +1437,8 @@ body.map-background .content-panel::-webkit-scrollbar-thumb {
 
 .social-links {
   display: flex;
-  flex-wrap: wrap;
   gap: 16px;
-  margin: 18px 0 24px;
+  margin-top: 24px;
 }
 
 .social-links a {
@@ -1583,8 +1469,6 @@ body.map-background .content-panel::-webkit-scrollbar-thumb {
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   border: none;
   cursor: pointer;
-  box-sizing: border-box;
-  max-width: 100%;
 }
 
 .cta:hover,
@@ -2028,7 +1912,7 @@ body.page-route-finder #map::after {
 
 .delivery-banner {
   position: fixed;
-  top: calc(var(--topbar-height, 56px) + 16px);
+  top: 56px;
   left: 0;
   right: 0;
   padding: 14px 24px;
@@ -2298,46 +2182,6 @@ body.page-route-finder #map::after {
     right: 10px;
     box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
   }
-
-  body.page-home,
-  body.page-delivery,
-  body.page-community,
-  body.page-registration,
-  body.page-about {
-    --overlay-panel-top: 92px;
-    --overlay-panel-max-height: calc(100vh - 104px);
-  }
-
-  body.page-home .content-panel[data-draggable-overlay],
-  body.page-delivery .content-panel[data-draggable-overlay],
-  body.page-community .content-panel[data-draggable-overlay],
-  body.page-registration .content-panel[data-draggable-overlay],
-  body.page-about .content-panel[data-draggable-overlay] {
-    --overlay-mobile-offset: 20px;
-    --overlay-mobile-bottom-gap: clamp(32px, 9vh, 56px);
-    top: calc(var(--overlay-panel-top) + var(--overlay-mobile-offset));
-    display: flex;
-    flex-direction: column;
-    width: min(360px, calc(100% - 24px));
-    max-height: min(
-      82vh,
-      calc(100vh - var(--overlay-panel-top) - var(--overlay-mobile-offset) - var(--overlay-mobile-bottom-gap))
-    );
-    padding: 26px 24px 30px;
-    touch-action: pan-y;
-    overflow: hidden;
-  }
-
-  body.page-home .content-panel[data-draggable-overlay] [data-overlay-body],
-  body.page-delivery .content-panel[data-draggable-overlay] [data-overlay-body],
-  body.page-community .content-panel[data-draggable-overlay] [data-overlay-body],
-  body.page-registration .content-panel[data-draggable-overlay] [data-overlay-body],
-  body.page-about .content-panel[data-draggable-overlay] [data-overlay-body] {
-    flex: 1 1 auto;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-    padding-right: 4px;
-  }
 }
 
 @media (max-width: 480px) {
@@ -2436,29 +2280,5 @@ body.page-route-finder #map::after {
   .overlay-toggle {
     top: 8px;
     right: 8px;
-  }
-
-  body.page-home .content-panel[data-draggable-overlay],
-  body.page-delivery .content-panel[data-draggable-overlay],
-  body.page-community .content-panel[data-draggable-overlay],
-  body.page-registration .content-panel[data-draggable-overlay],
-  body.page-about .content-panel[data-draggable-overlay] {
-    --overlay-mobile-offset: 22px;
-    --overlay-mobile-bottom-gap: clamp(32px, 9vh, 56px);
-    top: calc(var(--overlay-panel-top) + var(--overlay-mobile-offset));
-    width: min(340px, calc(100% - 20px));
-    max-height: min(
-      84vh,
-      calc(100vh - var(--overlay-panel-top) - var(--overlay-mobile-offset) - var(--overlay-mobile-bottom-gap))
-    );
-    padding: 24px 20px 28px;
-  }
-
-  body.page-home .content-panel[data-draggable-overlay] [data-overlay-body],
-  body.page-delivery .content-panel[data-draggable-overlay] [data-overlay-body],
-  body.page-community .content-panel[data-draggable-overlay] [data-overlay-body],
-  body.page-registration .content-panel[data-draggable-overlay] [data-overlay-body],
-  body.page-about .content-panel[data-draggable-overlay] [data-overlay-body] {
-    padding-right: 2px;
   }
 }

--- a/client/styles.css
+++ b/client/styles.css
@@ -2310,11 +2310,16 @@ body.page-route-finder #map::after {
   body.page-community .content-panel[data-draggable-overlay],
   body.page-registration .content-panel[data-draggable-overlay],
   body.page-about .content-panel[data-draggable-overlay] {
-    top: calc(var(--overlay-panel-top) + 20px);
+    --overlay-mobile-offset: 20px;
+    --overlay-mobile-bottom-gap: clamp(18px, 6vh, 32px);
+    top: calc(var(--overlay-panel-top) + var(--overlay-mobile-offset));
     display: flex;
     flex-direction: column;
     width: min(360px, calc(100% - 24px));
-    max-height: min(82vh, calc(var(--overlay-panel-max-height) - 16px));
+    max-height: min(
+      82vh,
+      calc(100vh - var(--overlay-panel-top) - var(--overlay-mobile-offset) - var(--overlay-mobile-bottom-gap))
+    );
     padding: 26px 24px 30px;
     touch-action: pan-y;
     overflow: hidden;
@@ -2435,9 +2440,14 @@ body.page-route-finder #map::after {
   body.page-community .content-panel[data-draggable-overlay],
   body.page-registration .content-panel[data-draggable-overlay],
   body.page-about .content-panel[data-draggable-overlay] {
-    top: calc(var(--overlay-panel-top) + 22px);
+    --overlay-mobile-offset: 22px;
+    --overlay-mobile-bottom-gap: clamp(18px, 6vh, 32px);
+    top: calc(var(--overlay-panel-top) + var(--overlay-mobile-offset));
     width: min(340px, calc(100% - 20px));
-    max-height: min(84vh, calc(var(--overlay-panel-max-height) - 20px));
+    max-height: min(
+      84vh,
+      calc(100vh - var(--overlay-panel-top) - var(--overlay-mobile-offset) - var(--overlay-mobile-bottom-gap))
+    );
     padding: 24px 20px 28px;
   }
 

--- a/client/styles.css
+++ b/client/styles.css
@@ -1177,7 +1177,7 @@ body.nav-open {
 }
 
 [data-overlay-body] {
-  touch-action: auto;
+  touch-action: pan-y;
 }
 
 .overlay-toggle {
@@ -2221,10 +2221,11 @@ body.page-route-finder #map::after {
   body.page-community .content-panel[data-draggable-overlay],
   body.page-registration .content-panel[data-draggable-overlay],
   body.page-about .content-panel[data-draggable-overlay] {
+    top: calc(var(--overlay-panel-top) + 16px);
     display: flex;
     flex-direction: column;
     width: min(360px, calc(100% - 24px));
-    max-height: min(88vh, calc(var(--overlay-panel-max-height) + 48px));
+    max-height: min(82vh, calc(var(--overlay-panel-max-height) - 16px));
     padding: 26px 24px 30px;
     touch-action: pan-y;
     overflow: hidden;
@@ -2345,7 +2346,9 @@ body.page-route-finder #map::after {
   body.page-community .content-panel[data-draggable-overlay],
   body.page-registration .content-panel[data-draggable-overlay],
   body.page-about .content-panel[data-draggable-overlay] {
+    top: calc(var(--overlay-panel-top) + 18px);
     width: min(340px, calc(100% - 20px));
+    max-height: min(84vh, calc(var(--overlay-panel-max-height) - 20px));
     padding: 24px 20px 28px;
   }
 

--- a/client/styles.css
+++ b/client/styles.css
@@ -1550,8 +1550,9 @@ body.map-background .content-panel::-webkit-scrollbar-thumb {
 
 .social-links {
   display: flex;
+  flex-wrap: wrap;
   gap: 16px;
-  margin-top: 24px;
+  margin: 18px 0 24px;
 }
 
 .social-links a {
@@ -1582,6 +1583,8 @@ body.map-background .content-panel::-webkit-scrollbar-thumb {
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   border: none;
   cursor: pointer;
+  box-sizing: border-box;
+  max-width: 100%;
 }
 
 .cta:hover,
@@ -2311,7 +2314,7 @@ body.page-route-finder #map::after {
   body.page-registration .content-panel[data-draggable-overlay],
   body.page-about .content-panel[data-draggable-overlay] {
     --overlay-mobile-offset: 20px;
-    --overlay-mobile-bottom-gap: clamp(18px, 6vh, 32px);
+    --overlay-mobile-bottom-gap: clamp(32px, 9vh, 56px);
     top: calc(var(--overlay-panel-top) + var(--overlay-mobile-offset));
     display: flex;
     flex-direction: column;
@@ -2441,7 +2444,7 @@ body.page-route-finder #map::after {
   body.page-registration .content-panel[data-draggable-overlay],
   body.page-about .content-panel[data-draggable-overlay] {
     --overlay-mobile-offset: 22px;
-    --overlay-mobile-bottom-gap: clamp(18px, 6vh, 32px);
+    --overlay-mobile-bottom-gap: clamp(32px, 9vh, 56px);
     top: calc(var(--overlay-panel-top) + var(--overlay-mobile-offset));
     width: min(340px, calc(100% - 20px));
     max-height: min(

--- a/client/styles.css
+++ b/client/styles.css
@@ -9,6 +9,7 @@
   --safe-area-right: env(safe-area-inset-right, 0px);
   --safe-area-bottom: env(safe-area-inset-bottom, 0px);
   --safe-area-left: env(safe-area-inset-left, 0px);
+  --topbar-height: 72px;
 }
 
 html, body {
@@ -2024,7 +2025,7 @@ body.page-route-finder #map::after {
 
 .delivery-banner {
   position: fixed;
-  top: 56px;
+  top: calc(var(--topbar-height, 56px) + 16px);
   left: 0;
   right: 0;
   padding: 14px 24px;

--- a/client/styles.css
+++ b/client/styles.css
@@ -1173,11 +1173,15 @@ body.nav-open {
 }
 
 .overlay-body {
-  display: contents;
+  display: block;
+  width: 100%;
+  min-height: 0;
 }
 
 [data-overlay-body] {
   touch-action: pan-y;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .overlay-toggle {

--- a/client/styles.css
+++ b/client/styles.css
@@ -2216,7 +2216,7 @@ body.page-route-finder #map::after {
   body.page-community,
   body.page-registration,
   body.page-about {
-    --overlay-panel-top: 76px;
+    --overlay-panel-top: 92px;
     --overlay-panel-max-height: calc(100vh - 104px);
   }
 
@@ -2225,7 +2225,7 @@ body.page-route-finder #map::after {
   body.page-community .content-panel[data-draggable-overlay],
   body.page-registration .content-panel[data-draggable-overlay],
   body.page-about .content-panel[data-draggable-overlay] {
-    top: calc(var(--overlay-panel-top) + 16px);
+    top: calc(var(--overlay-panel-top) + 20px);
     display: flex;
     flex-direction: column;
     width: min(360px, calc(100% - 24px));
@@ -2350,7 +2350,7 @@ body.page-route-finder #map::after {
   body.page-community .content-panel[data-draggable-overlay],
   body.page-registration .content-panel[data-draggable-overlay],
   body.page-about .content-panel[data-draggable-overlay] {
-    top: calc(var(--overlay-panel-top) + 18px);
+    top: calc(var(--overlay-panel-top) + 22px);
     width: min(340px, calc(100% - 20px));
     max-height: min(84vh, calc(var(--overlay-panel-max-height) - 20px));
     padding: 24px 20px 28px;

--- a/client/styles.css
+++ b/client/styles.css
@@ -924,6 +924,48 @@ body.nav-open {
   flex: 1 1 auto;
 }
 
+.route-adder-saved__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.route-adder-saved__action {
+  appearance: none;
+  border: 1px solid rgba(37, 99, 235, 0.45);
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 6px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  text-align: center;
+}
+
+.route-adder-saved__action:hover,
+.route-adder-saved__action:focus {
+  outline: none;
+  background: rgba(37, 99, 235, 0.18);
+  border-color: rgba(37, 99, 235, 0.6);
+  color: #1e3a8a;
+}
+
+.route-adder-saved__action:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.45);
+  outline-offset: 2px;
+}
+
+.route-adder-saved__action[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  background: rgba(148, 163, 184, 0.2);
+  border-color: rgba(148, 163, 184, 0.45);
+  color: rgba(71, 85, 105, 0.9);
+}
+
 .route-adder-saved__item-name {
   display: block;
   font-weight: 600;
@@ -941,12 +983,6 @@ body.nav-open {
   font-size: 0.8rem;
   color: rgba(37, 99, 235, 0.75);
   margin-top: 4px;
-}
-
-.route-adder-saved__actions {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
 }
 
 .route-adder-saved__empty {
@@ -978,6 +1014,10 @@ body.nav-open {
   z-index: 1200;
 }
 
+.route-save-dialog[hidden] {
+  display: none !important;
+}
+
 .route-save-dialog__form {
   display: grid;
   gap: 16px;
@@ -1005,6 +1045,38 @@ body.nav-open {
 .route-save-dialog__list label {
   font-weight: 600;
   color: rgba(15, 23, 42, 0.85);
+}
+
+.route-save-dialog__contributor {
+  list-style: none;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  border-radius: 12px;
+  padding: 14px 16px;
+  margin-top: 4px;
+}
+
+.route-save-dialog__contributor-heading {
+  font-weight: 600;
+  color: #1d4ed8;
+  margin-bottom: 6px;
+}
+
+.route-save-dialog__contributor-line {
+  margin: 2px 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.8);
+}
+
+.route-save-dialog__contributor-line strong {
+  font-weight: 600;
+  color: rgba(30, 64, 175, 0.95);
+}
+
+.route-save-dialog__contributor-hint {
+  margin: 8px 0 0;
+  font-size: 0.8rem;
+  color: rgba(71, 85, 105, 0.85);
 }
 
 .route-save-dialog__list input {

--- a/client/styles.css
+++ b/client/styles.css
@@ -45,21 +45,24 @@ body.map-background {
   top: 0;
   left: 0;
   right: 0;
-  min-height: 60px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 255, 0.78));
-  backdrop-filter: blur(14px);
+  min-height: 58px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(219, 234, 254, 0.85));
+  backdrop-filter: blur(18px);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 14px 20px;
+  gap: 14px;
+  padding: 12px clamp(18px, 6vw, 28px);
   box-sizing: border-box;
   z-index: 1200;
   font-weight: 600;
   letter-spacing: 0.01em;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
-  border-bottom-left-radius: 24px;
-  border-bottom-right-radius: 24px;
+  box-shadow: 0 22px 46px rgba(15, 23, 42, 0.16);
+  border-bottom-left-radius: 26px;
+  border-bottom-right-radius: 26px;
+  border-left: 1px solid rgba(148, 163, 184, 0.2);
+  border-right: 1px solid rgba(148, 163, 184, 0.2);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.32);
 }
 
 #topbar a {
@@ -69,16 +72,18 @@ body.map-background {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 14px;
+  padding: 8px 12px;
   border-radius: 14px;
-  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid transparent;
+  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 #topbar a:hover,
 #topbar a:focus {
   color: #1d4ed8;
-  background: rgba(37, 99, 235, 0.14);
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.16);
+  background: rgba(59, 130, 246, 0.14);
+  border-color: rgba(59, 130, 246, 0.28);
+  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.2);
 }
 
 .topbar__account {
@@ -92,31 +97,33 @@ body.map-background {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 12px;
-  border: none;
+  padding: 6px 16px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.08);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.82), rgba(226, 232, 255, 0.68));
   color: #0f172a;
   font: inherit;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .topbar__account-toggle:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.35);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.28);
 }
 
 .topbar__account-toggle:hover,
 .topbar__account-toggle:focus-visible {
-  background: rgba(37, 99, 235, 0.18);
+  background: rgba(59, 130, 246, 0.16);
   color: #1d4ed8;
+  border-color: rgba(59, 130, 246, 0.32);
 }
 
 .topbar__account--open .topbar__account-toggle {
-  background: rgba(37, 99, 235, 0.2);
+  background: linear-gradient(145deg, rgba(37, 99, 235, 0.18), rgba(59, 130, 246, 0.28));
   color: #1d4ed8;
+  border-color: rgba(59, 130, 246, 0.38);
 }
 
 .topbar__account-caret {
@@ -137,6 +144,7 @@ body.map-background {
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
   z-index: 1200;
   color: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.22);
 }
 
 .topbar__account-menu[hidden] {
@@ -260,28 +268,39 @@ body.map-background {
 
 #topbar a[aria-current="page"] {
   color: #1d4ed8;
-  background: rgba(37, 99, 235, 0.2);
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.32);
   box-shadow: 0 16px 32px rgba(37, 99, 235, 0.22);
 }
 
 .topbar__brand[aria-current="page"] {
-  background: none;
-  box-shadow: none;
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.35);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.2);
+  color: #1d4ed8;
 }
 
 .topbar__brand {
-  font-size: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  font-size: 1.05rem;
   font-weight: 800;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  padding: 0;
-  color: #111827;
+  color: #0f172a;
 }
 
 .topbar__brand:hover,
 .topbar__brand:focus {
-  background: none;
-  box-shadow: none;
+  background: rgba(59, 130, 246, 0.16);
+  border-color: rgba(59, 130, 246, 0.28);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.18);
   color: #1d4ed8;
 }
 
@@ -290,22 +309,22 @@ body.map-background {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 46px;
-  height: 46px;
+  width: 44px;
+  height: 44px;
   border-radius: 16px;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 255, 0.75));
   color: #0f172a;
   cursor: pointer;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.14);
   transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
 .topbar__menu:hover,
 .topbar__menu:focus {
-  border-color: rgba(37, 99, 235, 0.45);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 18px 30px rgba(37, 99, 235, 0.2);
+  border-color: rgba(59, 130, 246, 0.38);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 18px 34px rgba(37, 99, 235, 0.22);
 }
 
 .topbar__menu-icon {
@@ -326,10 +345,10 @@ body.map-background {
 }
 
 #topbar[data-nav-open="true"] .topbar__menu {
-  border-color: transparent;
-  background: #1d4ed8;
+  border-color: rgba(37, 99, 235, 0.5);
+  background: linear-gradient(145deg, #1d4ed8, #2563eb);
   color: #ffffff;
-  box-shadow: 0 20px 36px rgba(37, 99, 235, 0.3);
+  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.32);
 }
 
 #topbar[data-nav-open="true"] .topbar__menu-line:nth-child(1) {
@@ -356,26 +375,25 @@ body.nav-open {
   right: 0;
   bottom: auto;
   --mobile-nav-max-height: 100dvh;
+  --mobile-nav-height: auto;
   max-height: min(100dvh, var(--mobile-nav-max-height));
-  height: auto;
-  width: min(340px, 82vw);
+  height: var(--mobile-nav-height, auto);
+  width: min(340px, 84vw);
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  padding: clamp(80px, 18vh, 120px) clamp(22px, 6vw, 32px) clamp(28px, 9vh, 44px);
-  padding-top: calc(env(safe-area-inset-top, 0) + 72px);
-  padding-bottom: calc(env(safe-area-inset-bottom, 0) + 36px);
+  gap: 18px;
+  padding: calc(env(safe-area-inset-top, 0) + 36px) clamp(20px, 6vw, 28px) calc(env(safe-area-inset-bottom, 0) + 28px);
   background: rgba(255, 255, 255, 0.96);
   backdrop-filter: blur(18px);
   box-shadow: -28px 0 60px rgba(15, 23, 42, 0.25);
-  border-top-left-radius: 28px;
-  border-bottom-left-radius: 28px;
+  border-top-left-radius: 26px;
+  border-bottom-left-radius: 26px;
   transform: translateX(110%);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
   transition: transform 0.32s ease, opacity 0.32s ease, visibility 0.32s ease;
-  overflow-y: auto;
+  overflow-y: hidden;
   box-sizing: border-box;
   scrollbar-gutter: stable;
   z-index: 1300;
@@ -388,21 +406,26 @@ body.nav-open {
   pointer-events: auto;
 }
 
+.mobile-nav--scrollable {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .mobile-nav__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .mobile-nav__title {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: 0.28em;
+  letter-spacing: 0.3em;
   text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.68);
+  color: rgba(15, 23, 42, 0.7);
 }
 
 .mobile-nav__close {
@@ -466,8 +489,10 @@ body.nav-open {
 }
 
 #topbar[data-nav-mode='desktop'] .mobile-nav {
+  --mobile-nav-height: auto;
   max-height: none;
   height: auto;
+  overflow: visible;
 }
 
 #topbar[data-nav-mode='desktop'] .mobile-nav__backdrop {
@@ -483,7 +508,7 @@ body.nav-open {
 .topbar__links {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
   margin: 0;
   padding: 12px 0 0;
 }
@@ -494,7 +519,7 @@ body.nav-open {
   background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.08));
   color: #0f172a;
   border-radius: 18px;
-  padding: 14px 18px;
+  padding: 12px 16px;
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.1);
 }
 
@@ -518,11 +543,11 @@ body.nav-open {
 
 @media (min-width: 900px) {
   #topbar {
-    padding: 18px 40px;
+    padding: 16px clamp(32px, 5vw, 48px);
     gap: 20px;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.16);
   }
 
   .topbar__menu {

--- a/client/styles.css
+++ b/client/styles.css
@@ -563,19 +563,6 @@ body.nav-open {
   outline-offset: 4px;
 }
 
-.topbar__links a::after {
-  content: '\u203A';
-  font-size: 1rem;
-  opacity: 0.55;
-  transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-.topbar__links a:hover::after,
-.topbar__links a:focus-visible::after {
-  transform: translateX(4px);
-  opacity: 0.85;
-}
-
 @media (min-width: 900px) {
   #topbar {
     --topbar-padding-inline: clamp(32px, 5vw, 48px);

--- a/client/styles.css
+++ b/client/styles.css
@@ -354,12 +354,17 @@ body.nav-open {
   position: fixed;
   top: 0;
   right: 0;
-  bottom: 0;
+  bottom: auto;
+  --mobile-nav-max-height: 100dvh;
+  max-height: min(100dvh, var(--mobile-nav-max-height));
+  height: min(100dvh, var(--mobile-nav-max-height));
   width: min(340px, 82vw);
   display: flex;
   flex-direction: column;
   gap: 20px;
-  padding: clamp(96px, 20vh, 140px) clamp(22px, 6vw, 32px) 28px;
+  padding: clamp(80px, 18vh, 120px) clamp(22px, 6vw, 32px) clamp(28px, 9vh, 44px);
+  padding-top: calc(env(safe-area-inset-top, 0) + 72px);
+  padding-bottom: calc(env(safe-area-inset-bottom, 0) + 36px);
   background: rgba(255, 255, 255, 0.96);
   backdrop-filter: blur(18px);
   box-shadow: -28px 0 60px rgba(15, 23, 42, 0.25);
@@ -371,6 +376,7 @@ body.nav-open {
   pointer-events: none;
   transition: transform 0.32s ease, opacity 0.32s ease, visibility 0.32s ease;
   overflow-y: auto;
+  box-sizing: border-box;
   scrollbar-gutter: stable;
   z-index: 1300;
 }
@@ -529,6 +535,9 @@ body.nav-open {
     backdrop-filter: none;
     box-shadow: none;
     border-radius: 0;
+    height: auto;
+    max-height: none;
+    min-height: 0;
     overflow: visible;
   }
 
@@ -1038,6 +1047,12 @@ body.nav-open {
   box-sizing: border-box;
   pointer-events: auto;
   overflow: visible;
+  touch-action: none;
+  cursor: grab;
+}
+
+.overlay-panel:active {
+  cursor: grabbing;
 }
 
 .overlay-panel.route-adder-saved,
@@ -1099,6 +1114,10 @@ body.nav-open {
 
 .overlay-body {
   display: contents;
+}
+
+[data-overlay-body] {
+  touch-action: auto;
 }
 
 .overlay-toggle {

--- a/client/styles.css
+++ b/client/styles.css
@@ -357,7 +357,7 @@ body.nav-open {
   bottom: auto;
   --mobile-nav-max-height: 100dvh;
   max-height: min(100dvh, var(--mobile-nav-max-height));
-  height: min(100dvh, var(--mobile-nav-max-height));
+  height: auto;
   width: min(340px, 82vw);
   display: flex;
   flex-direction: column;
@@ -463,6 +463,15 @@ body.nav-open {
   pointer-events: none;
   transition: opacity 0.32s ease, visibility 0.32s ease;
   z-index: 1250;
+}
+
+#topbar[data-nav-mode='desktop'] .mobile-nav {
+  max-height: none;
+  height: auto;
+}
+
+#topbar[data-nav-mode='desktop'] .mobile-nav__backdrop {
+  display: none !important;
 }
 
 #topbar[data-nav-open="true"] .mobile-nav__backdrop {

--- a/client/styles.css
+++ b/client/styles.css
@@ -252,7 +252,7 @@ body.map-background {
     margin-left: calc(-1 * var(--topbar-padding-inline));
     margin-right: calc(-1 * var(--topbar-padding-inline));
     padding: 8px calc(var(--topbar-padding-inline) + var(--safe-area-right))
-      calc(14px + var(--safe-area-bottom))
+      calc(7px + var(--safe-area-bottom))
       calc(var(--topbar-padding-inline) + var(--safe-area-left));
     box-sizing: border-box;
     justify-content: flex-start;

--- a/server.js
+++ b/server.js
@@ -1077,7 +1077,7 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  const relativePath = pathname === '/' ? 'index.html' : pathname;
+  const relativePath = pathname === '/' ? 'route-finder.html' : pathname;
   const filePath = path.join('client', relativePath);
   if (!filePath.startsWith('client')) {
     res.writeHead(403);

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,9 @@ const routes = [
   {
     routeId: 'sample',
     name: 'Sample Route',
+    pointAName: 'Downtown Taxi Rank',
+    pointBName: 'Airport Terminal A',
+    notes: 'Peak-hour taxis run every 10 minutes. Expect light traffic after 19:00.',
     fare: { min: 10, max: 15, currency: 'ZAR' },
     gesture: 'raise hand',
     stops: [{ name: 'Stop A', lat: -26.2041, lng: 28.0473 }],


### PR DESCRIPTION
## Summary
- calculate a dynamic mobile navigation height and update styles so the drawer expands just enough to show every link while keeping desktop layout unchanged
- refine overlay dragging to honour scroll boundaries, maintain pointer capture, and let panels tuck into screen edges from any touch point

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb73af56b8832eb24bc1e38f785385